### PR TITLE
Fix JWT compilation errors and improve testing pipeline

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,6 +22,17 @@ jobs:
         credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
     - name: 'Set up Cloud SDK'
       uses: 'google-github-actions/setup-gcloud@v1'
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+    - name: Test java service
+      run: |
+        cd java/server && mvn test
+    - name: Test java-auth service
+      run: |
+        cd java-auth/server && mvn test
     - name: build
       run: |
         gcloud auth configure-docker

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,8 +9,27 @@ on:
       - master
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v3
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+    - name: Test java service
+      run: |
+        cd java/server && mvn test
+    - name: Test java-auth service
+      run: |
+        cd java-auth/server && mvn test
+
   build:
     runs-on: ubuntu-latest
+    needs: test
+    if: github.ref == 'refs/heads/master'
     steps:
     - name: checkout
       uses: actions/checkout@v3
@@ -25,17 +44,6 @@ jobs:
         credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
     - name: 'Set up Cloud SDK'
       uses: 'google-github-actions/setup-gcloud@v1'
-    - name: Set up JDK 17
-      uses: actions/setup-java@v4
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-    - name: Test java service
-      run: |
-        cd java/server && mvn test
-    - name: Test java-auth service
-      run: |
-        cd java-auth/server && mvn test
     - name: build
       run: |
         gcloud auth configure-docker

--- a/java-auth/server/src/test/java/com/example/auth/controller/AuthControllerTest.java
+++ b/java-auth/server/src/test/java/com/example/auth/controller/AuthControllerTest.java
@@ -12,17 +12,22 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+import com.example.auth.security.SecurityConfig;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(AuthController.class)
+@WebMvcTest(controllers = AuthController.class)
+@Import(SecurityConfig.class)
 @ActiveProfiles("test")
 class AuthControllerTest {
 
@@ -70,7 +75,8 @@ class AuthControllerTest {
 
         mockMvc.perform(post("/api/auth/login")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(loginRequest)))
+                .content(objectMapper.writeValueAsString(loginRequest))
+                .with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.accessToken").value("test-access-token"))
                 .andExpect(jsonPath("$.refreshToken").value("test-refresh-token"))
@@ -84,7 +90,8 @@ class AuthControllerTest {
 
         mockMvc.perform(post("/api/auth/login")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(invalidRequest)))
+                .content(objectMapper.writeValueAsString(invalidRequest))
+                .with(csrf()))
                 .andExpect(status().isBadRequest());
     }
 }

--- a/java/server/pom.xml
+++ b/java/server/pom.xml
@@ -14,7 +14,7 @@
 	<name>server</name>
 	<description>Demo project for Spring Boot</description>
 	<properties>
-		<java.version>20</java.version>
+		<java.version>17</java.version>
 	</properties>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
- Updated JwtTokenProvider to use JJWT 0.12.3 API (replaced parserBuilder() with parser(), setSigningKey() with verifyWith())
- Fixed deprecation warnings by using new method names (subject() vs setSubject(), parseSignedClaims() vs parseClaimsJws())
- Fixed test configuration to properly import SecurityConfig and handle CSRF
- Updated GitHub Actions to run tests before building Docker images
- Standardized Java version to 17 across all services

🤖 Generated with [Claude Code](https://claude.ai/code)