### PR TITLE
fix: update Makefile and bump all versions to 1.1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,6 @@ update-version: ## Update VERSION file and all manifests/configs (usage: make up
 	@sed -i '' '/<artifactId>jwt-generator<\/artifactId>/,+1 s|<version>[^<]*</version>|<version>$(VERSION)</version>|' java-auth/scripts/pom.xml
 	@echo "Updating Node package.json..."
 	@sed -i '' 's|"version": "[0-9.]*"|"version": "$(VERSION)"|' node/package.json
-	@echo "Updating documentation..."
-	@sed -i '' 's|gcr.io/speedscale-demos/java-auth[^:]*:[v]*[0-9.]*|gcr.io/speedscale-demos/java-auth:$(VERSION)|g' java-auth/IMPLEMENTATION_TASKS.md
-	@sed -i '' 's|gcr.io/speedscale-demos/java-auth-client[^:]*:[v]*[0-9.]*|gcr.io/speedscale-demos/java-auth-client:$(VERSION)|g' java-auth/IMPLEMENTATION_TASKS.md
 	@echo ""
 	@echo "✅ Version $(VERSION) updated across all files!"
 	@echo ""

--- a/java-auth/k8s/base/auth-client-deployment.yaml
+++ b/java-auth/k8s/base/auth-client-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         command: ['sh', '-c', 'until wget -q --spider http://java-auth-service:80/actuator/health/readiness; do echo waiting for java-auth service; sleep 5; done;']
       containers:
       - name: java-auth-client
-        image: gcr.io/speedscale-demos/java-auth-client:1.0.11
+        image: gcr.io/speedscale-demos/java-auth-client:1.1.0
         imagePullPolicy: Always
         env:
         - name: SERVER_URL

--- a/java-auth/k8s/base/auth-deployment.yaml
+++ b/java-auth/k8s/base/auth-deployment.yaml
@@ -23,7 +23,7 @@ spec:
         command: ['sh', '-c', 'until nc -z mysql-service 3306; do echo waiting for mysql; sleep 2; done;']
       containers:
       - name: java-auth
-        image: gcr.io/speedscale-demos/java-auth:1.0.11
+        image: gcr.io/speedscale-demos/java-auth:1.1.0
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/java-auth/scripts/pom.xml
+++ b/java-auth/scripts/pom.xml
@@ -7,7 +7,7 @@
     
     <groupId>com.example.auth.scripts</groupId>
     <artifactId>jwt-generator</artifactId>
-    <version>1.0.11</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
     
     <properties>

--- a/java/manifest.yaml
+++ b/java/manifest.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: java-server
-          image: gcr.io/speedscale-demos/java-server:v1.0.11
+          image: gcr.io/speedscale-demos/java-server:v1.1.0
           imagePullPolicy: Always
           readinessProbe:
             httpGet:

--- a/java/server/pom.xml
+++ b/java/server/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>speedscale</groupId>
 	<artifactId>server</artifactId>
-	<version>1.0.11</version>
+	<version>1.1.0</version>
 	<name>server</name>
 	<description>Demo project for Spring Boot</description>
 	<properties>

--- a/node/manifest.yaml
+++ b/node/manifest.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: node-server
-          image: gcr.io/speedscale-demos/node-server:v1.0.11
+          image: gcr.io/speedscale-demos/node-server:v1.1.0
           imagePullPolicy: Always
           readinessProbe:
             httpGet:

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-server",
-  "version": "1.0.11",
+  "version": "1.1.0",
   "description": "demo app for node",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Remove references to deleted IMPLEMENTATION_TASKS.md file from Makefile
- Update all Kubernetes manifests to use version 1.1.0
- Update all pom.xml files to version 1.1.0
- Update Node package.json to version 1.1.0

The update-version command was failing because it tried to update a non-existent file, preventing the Kubernetes manifests from being updated properly.

🤖 Generated with [Claude Code](https://claude.ai/code)