### PR TITLE
fix: update Docker base images to amazoncorretto:20 and enhance README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,38 @@
 # Speedscale Demos
 
-This repo contains different self contained demo apps in each subdirectory.
+This repository contains various self-contained demo applications that showcase different programming languages, frameworks, and deployment patterns. Each demo is designed to work with Speedscale's traffic recording, mocking, and replay capabilities.
+
+## Demo Projects
+
+### [Java](java/)
+A Spring Boot application that integrates with external APIs (SpaceX and US Treasury). Features JWT authentication, health checks, and comprehensive API endpoints for testing traffic capture and replay scenarios.
+
+### [Java Auth](java-auth/)
+A complete JWT-based authentication microservice built with Spring Boot and MySQL. Includes user registration, login, token validation, refresh tokens, and audit logging. Perfect for demonstrating secure API interactions and database traffic patterns.
+
+### [Node.js](node/)
+A Node.js Express application with multiple endpoints that call external APIs including GitHub, SpaceX, NASA, and httpbin. Includes comprehensive documentation for local, Docker, and Kubernetes deployment scenarios.
+
+### [Go](go/)
+An IP distance calculator service that uses the ipstack API to determine geographical distances between IP addresses. Demonstrates API integration patterns and mathematical calculations in Go.
+
+### [Python](python/)
+A Flask application that proxies SpaceX API data, providing a simple example of Python-based API integration suitable for traffic capture and replay testing.
+
+### [Node API](node-api/)
+A Node.js/Express IP distance API similar to the Go version, featuring ipstack integration, haversine distance calculations, and optional DynamoDB caching with AWS SDK v3.
+
+### [C#/.NET](csharp/)
+A .NET weather service API that demonstrates C# web application patterns and external service integration capabilities.
+
+### [NGINX](nginx/)
+A Kubernetes-based demo featuring multiple nginx services (gateway, payment, user) that simulate a microservices architecture. Perfect for demonstrating service mesh traffic patterns.
+
+### [ArgoCD](argo/)
+A GitOps deployment solution using ArgoCD for multi-cluster Kubernetes deployments. Shows how to manage application deployments across different cluster environments.
+
+### [AWS Services](aws/)
+Contains AWS-specific demos including DynamoDB integration examples, demonstrating cloud service integration patterns.
 
 ## Version Management
 

--- a/java-auth/client/Dockerfile
+++ b/java-auth/client/Dockerfile
@@ -1,6 +1,4 @@
-FROM openjdk:17-jdk-alpine AS build
-
-RUN apk add --no-cache maven
+FROM maven:3-amazoncorretto-20 AS build
 
 WORKDIR /app
 COPY pom.xml .
@@ -8,7 +6,7 @@ COPY src ./src
 
 RUN mvn clean compile dependency:copy-dependencies
 
-FROM openjdk:17-jre-alpine
+FROM amazoncorretto:20
 
 WORKDIR /app
 COPY --from=build /app/target/classes ./classes

--- a/java-auth/server/Dockerfile
+++ b/java-auth/server/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM maven:3.9-eclipse-temurin-17 AS build
+FROM maven:3-amazoncorretto-20 AS build
 WORKDIR /app
 COPY pom.xml .
 RUN mvn dependency:go-offline -B
@@ -7,7 +7,7 @@ COPY src ./src
 RUN mvn clean package -DskipTests
 
 # Runtime stage
-FROM eclipse-temurin:17-jre
+FROM amazoncorretto:20
 RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 RUN groupadd -g 1001 spring && useradd -u 1001 -g spring -m spring
 USER spring:spring


### PR DESCRIPTION
- Fix CI build failures by updating java-auth containers to use amazoncorretto:20
- Replace deprecated openjdk:17-jre-alpine with amazoncorretto:20
- Update maven build image to maven:3-amazoncorretto-20
- Add comprehensive demo project overview to main README
- Include descriptions and links for all 10+ demo applications
- Maintain consistency with existing java/ Docker image standard

🤖 Generated with [Claude Code](https://claude.ai/code)