### PR TITLE
Standardize all Docker image tags to use v prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,8 @@ update-version: ## Update VERSION file and all manifests/configs (usage: make up
 	@echo "Updating to version $(VERSION)..."
 	@echo "$(VERSION)" > VERSION
 	@echo "Updating Kubernetes manifests..."
-	@sed -i '' 's|gcr.io/speedscale-demos/java-auth:[v]*[0-9.]*|gcr.io/speedscale-demos/java-auth:$(VERSION)|g' java-auth/k8s/base/auth-server/auth-deployment.yaml
-	@sed -i '' 's|gcr.io/speedscale-demos/java-auth-client:[v]*[0-9.]*|gcr.io/speedscale-demos/java-auth-client:$(VERSION)|g' java-auth/k8s/base/auth-client/auth-client-deployment.yaml
+	@sed -i '' 's|gcr.io/speedscale-demos/java-auth:[v]*[0-9.]*|gcr.io/speedscale-demos/java-auth:v$(VERSION)|g' java-auth/k8s/base/auth-server/auth-deployment.yaml
+	@sed -i '' 's|gcr.io/speedscale-demos/java-auth-client:[v]*[0-9.]*|gcr.io/speedscale-demos/java-auth-client:v$(VERSION)|g' java-auth/k8s/base/auth-client/auth-client-deployment.yaml
 	@sed -i '' 's|gcr.io/speedscale-demos/java-server:[v]*[0-9.]*|gcr.io/speedscale-demos/java-server:v$(VERSION)|g' java/manifest.yaml
 	@sed -i '' 's|gcr.io/speedscale-demos/node-server:[v]*[0-9.]*|gcr.io/speedscale-demos/node-server:v$(VERSION)|g' node/manifest.yaml
 	@sed -i '' 's|gcr.io/speedscale-demos/smart-replace-demo:[v]*[0-9.]*|gcr.io/speedscale-demos/smart-replace-demo:v$(VERSION)|g' smart-replace-demo/manifest.yaml

--- a/java-auth/Makefile
+++ b/java-auth/Makefile
@@ -1,6 +1,6 @@
 VERSION?=$(shell cat ../VERSION 2>/dev/null || echo "1.0.0")
-REGISTRY?=gcr.io/speedscale-demos/java-auth:${VERSION}
-CLIENT_REGISTRY?=gcr.io/speedscale-demos/java-auth-client:${VERSION}
+REGISTRY?=gcr.io/speedscale-demos/java-auth:v${VERSION}
+CLIENT_REGISTRY?=gcr.io/speedscale-demos/java-auth-client:v${VERSION}
 NAMESPACE?=default
 
 .PHONY: help build test run up down client local compose kube docker-build docker-multi

--- a/java-auth/k8s/base/auth-client/auth-client-deployment.yaml
+++ b/java-auth/k8s/base/auth-client/auth-client-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         command: ['sh', '-c', 'until wget -q --spider http://java-auth-service:80/actuator/health/readiness; do echo waiting for java-auth service; sleep 5; done;']
       containers:
       - name: java-auth-client
-        image: gcr.io/speedscale-demos/java-auth-client:1.1.9
+        image: gcr.io/speedscale-demos/java-auth-client:v1.1.9
         imagePullPolicy: Always
         env:
         - name: SERVER_URL

--- a/java-auth/k8s/base/auth-server/auth-deployment.yaml
+++ b/java-auth/k8s/base/auth-server/auth-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         command: ['sh', '-c', 'until nc -z mysql-service 3306; do echo waiting for mysql; sleep 2; done;']
       containers:
       - name: java-auth
-        image: gcr.io/speedscale-demos/java-auth:1.1.9
+        image: gcr.io/speedscale-demos/java-auth:v1.1.9
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/java/Makefile
+++ b/java/Makefile
@@ -1,5 +1,5 @@
 VERSION?=$(shell cat ../VERSION 2>/dev/null || echo "1.0.6")
-REGISTRY?=gcr.io/speedscale-demos/java-server:${VERSION}
+REGISTRY?=gcr.io/speedscale-demos/java-server:v${VERSION}
 NAMESPACE?=default
 
 .PHONY: build

--- a/node/Makefile
+++ b/node/Makefile
@@ -1,5 +1,5 @@
 VERSION?=$(shell cat ../VERSION 2>/dev/null || echo "1.0.4")
-REGISTRY?=gcr.io/speedscale-demos/node-server:${VERSION}
+REGISTRY?=gcr.io/speedscale-demos/node-server:v${VERSION}
 NAMESPACE?=default
 
 .PHONY: build


### PR DESCRIPTION
Ensures version tagging consistency across all services and workflows.

## Problem
Services were inconsistent with version tag prefixes:
- ❌ `java-auth:1.1.9`, `java-server:1.1.9`, `node-server:1.1.9` (no v)
- ✅ `ruby-api:v1.1.9`, `smart-replace-demo:v1.1.9` (with v)

## Solution
Standardize ALL services to use `v` prefix.

## Changes

### Makefiles (add v prefix to REGISTRY)
- `java-auth/Makefile`: `v${VERSION}`
- `java/Makefile`: `v${VERSION}`
- `node/Makefile`: `v${VERSION}`
- Root `Makefile`: Update sed patterns for java-auth

### Deployments (update to v1.1.9)
- `java-auth/k8s/base/auth-server/auth-deployment.yaml`
- `java-auth/k8s/base/auth-client/auth-client-deployment.yaml`

## Result
✅ **All services now use consistent format:**
- `gcr.io/speedscale-demos/java-auth:v1.1.9`
- `gcr.io/speedscale-demos/java-auth-client:v1.1.9`
- `gcr.io/speedscale-demos/java-server:v1.1.9`
- `gcr.io/speedscale-demos/node-server:v1.1.9`
- `gcr.io/speedscale-demos/ruby-api:v1.1.9`
- `gcr.io/speedscale-demos/ruby-client:v1.1.9`
- `gcr.io/speedscale-demos/smart-replace-demo:v1.1.9`

## Validation
```bash
make validate-version
```
All checks ✅

## Workflows Verified
1. **CI Pipeline**: VERSION file (1.1.9) → Makefile adds v → Produces v1.1.9 tags
2. **Version Bump**: `make bump-version` → Updates manifests with v prefix
3. **Manifests**: All use v-prefixed images