### PR TITLE
Change PUT /tasks/:id to use query parameter

### DIFF
--- a/ruby-api/app.rb
+++ b/ruby-api/app.rb
@@ -248,8 +248,14 @@ rescue PG::Error => e
 end
 
 # Update task
-put '/tasks/:id' do
+put '/tasks' do
   authenticate!
+
+  task_id = params['id']
+  unless task_id
+    status 400
+    return json({ error: 'Missing required query parameter: id' })
+  end
 
   request.body.rewind
   data = JSON.parse(request.body.read)
@@ -257,7 +263,7 @@ put '/tasks/:id' do
   conn = db_connection
   result = conn.exec_params(
     'UPDATE tasks SET title = $1, description = $2, status = $3, priority = $4, updated_at = CURRENT_TIMESTAMP WHERE id = $5 RETURNING *',
-    [data['title'], data['description'], data['status'], data['priority'], params[:id]]
+    [data['title'], data['description'], data['status'], data['priority'], task_id]
   )
 
   if result.ntuples == 0

--- a/ruby-api/client/client.rb
+++ b/ruby-api/client/client.rb
@@ -239,7 +239,7 @@ class TasksClient
       priority: priorities.sample
     }
 
-    response = self.class.put("/tasks/#{task_id}",
+    response = self.class.put("/tasks?id=#{task_id}",
       headers: auth_headers,
       body: task.to_json
     )

--- a/ruby-api/k8s/base/ruby-client/client-deployment.yaml
+++ b/ruby-api/k8s/base/ruby-client/client-deployment.yaml
@@ -28,7 +28,7 @@ spec:
             echo "Ruby server is ready!"
       containers:
         - name: ruby-client
-          image: gcr.io/speedscale-demos/ruby-client:v1.2.0
+          image: gcr.io/speedscale-demos/ruby-client:v1.2.1
           imagePullPolicy: Always
           env:
             - name: SERVER_URL

--- a/ruby-api/k8s/base/ruby-server/ruby-deployment.yaml
+++ b/ruby-api/k8s/base/ruby-server/ruby-deployment.yaml
@@ -26,7 +26,7 @@ spec:
             echo "PostgreSQL is ready!"
       containers:
         - name: ruby-server
-          image: gcr.io/speedscale-demos/ruby-api:v1.2.0
+          image: gcr.io/speedscale-demos/ruby-api:v1.2.1
           imagePullPolicy: Always
           ports:
             - containerPort: 3000


### PR DESCRIPTION
## Summary
- Update endpoint from `PUT /tasks/:id` to `PUT /tasks?id={id}`
- Reduces number of unique URLs in the API surface
- Update client to use query parameter format
- Bump version to v1.2.1

## Test plan
- [ ] Verify PUT /tasks?id={id} successfully updates tasks
- [ ] Confirm client correctly passes task ID as query parameter
- [ ] Test error handling when id parameter is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)