### PR TITLE
Add verified OTel replay gate scenario

### DIFF
--- a/scenarios/README.md
+++ b/scenarios/README.md
@@ -2,10 +2,11 @@
 
 Standard demo scenarios using **Java**, **.NET**, and **Node.js** apps. Deployments are **Kubernetes only**; version is managed from the repo root (see [AGENTS.md](../AGENTS.md)).
 
-| Scenario | Description |
-|----------|-------------|
-| **[Monolith](monolith/)** | Run a **single** app in K8s: **Java**, **.NET**, or **Node.js** (each project’s own manifests). |
-| **[Microservices](microservices/)** | **Java + .NET + Node** behind one gateway in the `demo-stack` namespace. |
+| Scenario                                              | Description                                                                                     |
+| ----------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| **[Monolith](monolith/)**                             | Run a **single** app in K8s: **Java**, **.NET**, or **Node.js** (each project’s own manifests). |
+| **[Microservices](microservices/)**                   | **Java + .NET + Node** behind one gateway in the `demo-stack` namespace.                        |
+| **[OTel Trace Replay Gate](otel-trace-replay-gate/)** | Minimal, verified proxymock record/replay merge-gate example using the `node/` demo.            |
 
 ---
 

--- a/scenarios/otel-trace-replay-gate/README.md
+++ b/scenarios/otel-trace-replay-gate/README.md
@@ -1,0 +1,47 @@
+# OTel Trace Replay Gate (Verified Minimal Example)
+
+This scenario is a small example that has been validated with real commands in this repo.
+
+It uses the `node/` demo service and shows:
+
+1. Record production-shaped HTTP traffic through proxymock
+2. Replay that traffic against a running app
+3. Fail CI when replay checks fail
+
+## Files in this example
+
+```text
+scenarios/otel-trace-replay-gate/
+  README.md
+  otel/collector-replay-candidates.yaml
+  github-actions/replay-gate.yml
+  run-example.sh
+```
+
+## Verified local run
+
+From the repo root:
+
+```bash
+./scenarios/otel-trace-replay-gate/run-example.sh
+```
+
+What this script does:
+
+- installs `node/` dependencies
+- records inbound requests via `proxymock record` to a local temp directory
+- sends real requests through proxymock inbound port (`http://localhost:4143`)
+- replays the captured traffic with `proxymock replay`
+- enforces explicit checks:
+  - `requests.failed != 0`
+  - `latency.p95 > 5000`
+
+## CI gate template
+
+Use `github-actions/replay-gate.yml` as a drop-in example for `.github/workflows/`.
+
+It records-and-replays in the same job so there is no dependency on pre-committed snapshot files.
+
+## OTel selection reference
+
+`otel/collector-replay-candidates.yaml` shows a conceptual OTel processor setup for selecting replay candidates. It is a selection pattern reference, not a complete collector deployment.

--- a/scenarios/otel-trace-replay-gate/github-actions/replay-gate.yml
+++ b/scenarios/otel-trace-replay-gate/github-actions/replay-gate.yml
@@ -1,0 +1,59 @@
+name: proxymock-replay-gate
+
+on:
+  pull_request:
+    branches: [master, main]
+
+jobs:
+  replay-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install proxymock
+        run: sh -c "$(curl -Lfs https://downloads.speedscale.com/proxymock/install-proxymock)"
+
+      - name: Install node demo dependencies
+        run: npm install --prefix node
+
+      - name: Record sample traffic
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf /tmp/pm-node-rec
+          proxymock record --timeout 20s --out /tmp/pm-node-rec --app-port 3000 -- npm start --prefix node > /tmp/pm-node-record.log 2>&1 &
+          PM_PID=$!
+          sleep 6
+          curl -sS http://localhost:4143/healthz >/dev/null
+          curl -sS http://localhost:4143/ >/dev/null
+          wait $PM_PID
+
+      - name: Start node service
+        shell: bash
+        run: |
+          npm start --prefix node > /tmp/pm-node-app.log 2>&1 &
+          echo $! > /tmp/node-app.pid
+          sleep 3
+
+      - name: Replay gate checks
+        shell: bash
+        run: |
+          proxymock replay \
+            --in /tmp/pm-node-rec \
+            --test-against http://localhost:3000 \
+            --fail-if "requests.failed != 0" \
+            --fail-if "latency.p95 > 5000" \
+            --output pretty
+
+      - name: Stop node service
+        if: always()
+        shell: bash
+        run: |
+          if [ -f /tmp/node-app.pid ]; then
+            kill "$(cat /tmp/node-app.pid)" || true
+          fi

--- a/scenarios/otel-trace-replay-gate/otel/collector-replay-candidates.yaml
+++ b/scenarios/otel-trace-replay-gate/otel/collector-replay-candidates.yaml
@@ -1,0 +1,18 @@
+processors:
+  filter/replay_candidates:
+    traces:
+      span:
+        - 'attributes["service.name"] == "checkout-service"'
+        - 'attributes["http.route"] == "/api/v2/payments/authorize"'
+
+  tail_sampling/replay_priority:
+    decision_wait: 10s
+    policies:
+      - name: errors
+        type: status_code
+        status_code:
+          status_codes: [ERROR]
+      - name: slow_requests
+        type: latency
+        latency:
+          threshold_ms: 2500

--- a/scenarios/otel-trace-replay-gate/run-example.sh
+++ b/scenarios/otel-trace-replay-gate/run-example.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+NODE_DIR="${ROOT_DIR}/node"
+REC_DIR="${TMPDIR:-/tmp}/pm-node-rec"
+
+echo "[1/5] Installing node demo dependencies"
+npm install --prefix "${NODE_DIR}" >/dev/null
+
+echo "[2/5] Recording traffic with proxymock"
+rm -rf "${REC_DIR}"
+proxymock record --timeout 20s --out "${REC_DIR}" --app-port 3000 -- npm start --prefix "${NODE_DIR}" >"${TMPDIR:-/tmp}/pm-node-record.log" 2>&1 &
+PM_PID=$!
+
+sleep 6
+curl -sS "http://localhost:4143/healthz" >/dev/null
+curl -sS "http://localhost:4143/" >/dev/null
+wait "${PM_PID}"
+
+echo "[3/5] Starting app for replay"
+npm start --prefix "${NODE_DIR}" >"${TMPDIR:-/tmp}/pm-node-app.log" 2>&1 &
+APP_PID=$!
+sleep 3
+
+echo "[4/5] Running replay gate checks"
+set +e
+proxymock replay \
+  --in "${REC_DIR}" \
+  --test-against http://localhost:3000 \
+  --fail-if "requests.failed != 0" \
+  --fail-if "latency.p95 > 5000" \
+  --output pretty
+STATUS=$?
+set -e
+
+echo "[5/5] Cleaning up"
+kill "${APP_PID}" >/dev/null 2>&1 || true
+wait "${APP_PID}" 2>/dev/null || true
+
+if [[ ${STATUS} -ne 0 ]]; then
+  echo "Replay gate failed"
+  exit ${STATUS}
+fi
+
+echo "Replay gate passed"


### PR DESCRIPTION
## Summary
- add a new `scenarios/otel-trace-replay-gate/` example showing an end-to-end proxymock record/replay merge gate
- include a runnable script (`run-example.sh`) that records HTTP traffic against the `node/` demo and replays it with explicit `--fail-if` checks
- add a GitHub Actions workflow template for record-and-replay in one job and link the scenario from `scenarios/README.md`

## Validation
- ran `./scenarios/otel-trace-replay-gate/run-example.sh` locally in this repo
- confirmed replay passes with `requests.failed != 0` and `latency.p95 > 5000` gate checks