### PR TITLE
Fix gateway npm audit failure

### DIFF
--- a/scenarios/microservices/gateway/package-lock.json
+++ b/scenarios/microservices/gateway/package-lock.json
@@ -344,9 +344,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",


### PR DESCRIPTION
## Summary
- Update `scenarios/microservices/gateway/package-lock.json` to resolve the `follow-redirects` moderate vulnerability (GHSA-r4q5-vmmm-2653).
- Bump transitive `follow-redirects` from `1.15.11` to `1.16.0` via `npm audit fix`.
- Restore green status for the dependency-security workflow's `npm ci + audit` step.

## Validation
- Ran the same audit loop used by CI across all npm projects:
  - `npm ci`
  - `npm audit --audit-level=moderate`
- Confirmed all audited directories now pass.