### PR TITLE
llm-demo: live vs simulated cost framing + per-model demo flow

### DIFF
--- a/llm-simulation-demo/.gitignore
+++ b/llm-simulation-demo/.gitignore
@@ -27,3 +27,6 @@ backend/.env
 
 # k8s secret with real keys
 k8s/api-keys.secret.yaml
+
+# TS incremental build cache
+frontend/tsconfig.tsbuildinfo

--- a/llm-simulation-demo/backend/.env.example
+++ b/llm-simulation-demo/backend/.env.example
@@ -10,4 +10,4 @@ DEFAULT_PROVIDER=openai
 ENABLE_SIMULATION_MODE=true
 
 # Local dev: point at the tools-service (see README "Running locally")
-TOOL_BASE_URL=http://127.0.0.1:8001
+TOOL_BASE_URL=http://localhost:8001

--- a/llm-simulation-demo/backend/app/main.py
+++ b/llm-simulation-demo/backend/app/main.py
@@ -11,6 +11,7 @@ import httpx
 from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse
 
 load_dotenv()
 
@@ -44,10 +45,10 @@ _ADAPTERS: Dict[str, Any] = {
 }
 
 _PROVIDER_MODELS: Dict[str, List[str]] = {
-    "openai":    ["gpt-5.4-mini", "gpt-5.4", "gpt-5.4-nano"],
-    "anthropic": ["claude-haiku-4-5", "claude-sonnet-4-5", "claude-opus-4-5"],
-    "gemini":    ["gemini-flash-latest", "gemini-flash-lite-latest", "gemini-pro-latest"],
-    "xai":       ["grok-4-1-fast-non-reasoning", "grok-4-1-fast-reasoning", "grok-4.20-0309-non-reasoning"],
+    "openai":    ["gpt-5.5", "gpt-5.4-mini", "gpt-5.4-nano"],
+    "anthropic": ["claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5-20251001"],
+    "gemini":    ["gemini-pro-latest", "gemini-flash-latest", "gemini-flash-lite-latest"],
+    "xai":       ["grok-4.20-0309-non-reasoning", "grok-4-1-fast-reasoning", "grok-4-1-fast-non-reasoning"],
 }
 
 _run_store: Dict[str, RunResult] = {}
@@ -149,6 +150,7 @@ async def run_task(request: RunRequest) -> RunResult:
 
     result = RunResult(
         request_id=request_id,
+        ticket_id=request.input.ticket_id,
         provider=request.provider,
         model=model_used,
         output=adapter_result.output,
@@ -157,6 +159,7 @@ async def run_task(request: RunRequest) -> RunResult:
         timing=TimingInfo(provider_ms=provider_ms, total_ms=total_ms),
         total_tokens=adapter_result.total_tokens,
         cost_usd=adapter_result.cost_usd,
+        mocked=adapter_result.mocked,
         error=provider_error,
     )
 
@@ -170,6 +173,94 @@ async def get_run(run_id: str):
     if not result:
         raise HTTPException(status_code=404, detail=f"Run '{run_id}' not found")
     return result
+
+
+@app.post("/api/run/stream")
+async def run_task_stream(request: RunRequest) -> StreamingResponse:
+    adapter = _ADAPTERS.get(request.provider)
+    if not adapter:
+        async def _err():
+            yield f"data: {json.dumps({'type': 'error', 'message': f'Unknown provider: {request.provider}'})}\n\n"
+        return StreamingResponse(_err(), media_type="text/event-stream")
+
+    total_start = time.monotonic()
+    request_id = f"req_{uuid.uuid4().hex}"
+    model_used = request.model or adapter.default_model
+
+    async def generate():
+        order_tool, policy_tool = await asyncio.gather(
+            _call_tool("lookup_order", f"/tools/order/{request.input.ticket_id}"),
+            _call_tool("lookup_policy", "/tools/policy/return-policy-v2"),
+        )
+        tool_calls = [order_tool, policy_tool]
+        yield f"data: {json.dumps({'type': 'tools', 'tool_calls': [tc.model_dump() for tc in tool_calls]})}\n\n"
+
+        context_parts: list[str] = []
+        if order_tool.status == "ok" and order_tool.result:
+            context_parts.append(f"Order Data: {json.dumps(order_tool.result)}")
+        if policy_tool.status == "ok" and policy_tool.result:
+            context_parts.append(f"Return Policy: {json.dumps(policy_tool.result)}")
+        context = "\n".join(context_parts)
+
+        steps: list[LLMStep] = []
+        step_data: dict[str, dict] = {}
+        mocked_any = False
+
+        try:
+            async for event in adapter.stream(request, context=context):
+                step = LLMStep(
+                    name=event.name,
+                    prompt_tokens=event.prompt_tokens,
+                    completion_tokens=event.completion_tokens,
+                    cost_usd=event.cost_usd,
+                    duration_ms=event.duration_ms,
+                )
+                steps.append(step)
+                step_data[event.name] = event.data
+                if event.mocked:
+                    mocked_any = True
+                yield f"data: {json.dumps({'type': 'step', 'name': event.name, 'data': event.data, 'prompt_tokens': event.prompt_tokens, 'completion_tokens': event.completion_tokens, 'cost_usd': event.cost_usd, 'duration_ms': event.duration_ms, 'mocked': event.mocked})}\n\n"
+        except ProviderError as exc:
+            yield f"data: {json.dumps({'type': 'error', 'message': str(exc)})}\n\n"
+            return
+
+        triage = step_data.get("triage", {})
+        analysis = step_data.get("analysis", {})
+        response = step_data.get("response", {})
+
+        output = OutputEnvelope(
+            severity=triage.get("severity", "medium"),
+            summary=analysis.get("summary", "Unable to analyze ticket."),
+            recommended_action=response.get("recommended_action", "Escalate to L2 engineering."),
+            root_cause=analysis.get("root_cause"),
+            response_draft=response.get("response_body"),
+        )
+        total_tokens = sum(s.prompt_tokens + s.completion_tokens for s in steps)
+        cost_usd = round(sum(s.cost_usd for s in steps), 6)
+        total_ms = int((time.monotonic() - total_start) * 1000)
+
+        result = RunResult(
+            request_id=request_id,
+            ticket_id=request.input.ticket_id,
+            provider=request.provider,
+            model=model_used,
+            output=output,
+            steps=steps,
+            tool_calls=tool_calls,
+            timing=TimingInfo(provider_ms=total_ms, total_ms=total_ms),
+            total_tokens=total_tokens,
+            cost_usd=cost_usd,
+            mocked=mocked_any,
+        )
+        _run_store[request_id] = result
+
+        yield f"data: {json.dumps({'type': 'complete', 'request_id': request_id, 'total_tokens': total_tokens, 'cost_usd': cost_usd, 'mocked': mocked_any})}\n\n"
+
+    return StreamingResponse(
+        generate(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
 
 
 @app.get("/api/runs")

--- a/llm-simulation-demo/backend/app/models/result.py
+++ b/llm-simulation-demo/backend/app/models/result.py
@@ -29,6 +29,7 @@ class TimingInfo(BaseModel):
 
 class RunResult(BaseModel):
     request_id: str
+    ticket_id: Optional[str] = None
     provider: str
     model: str
     output: OutputEnvelope
@@ -37,4 +38,5 @@ class RunResult(BaseModel):
     timing: TimingInfo
     total_tokens: int = 0
     cost_usd: float = 0.0
+    mocked: bool = False
     error: Optional[str] = None

--- a/llm-simulation-demo/backend/app/providers/anthropic_adapter.py
+++ b/llm-simulation-demo/backend/app/providers/anthropic_adapter.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import json
 import time
-from typing import Tuple
+from typing import Any, AsyncGenerator, Dict, Optional, Tuple
 
 import httpx
 import os
@@ -11,8 +12,10 @@ from app.models.result import LLMStep, OutputEnvelope
 from app.providers.base import (
     AdapterResult,
     ProviderError,
+    StepEvent,
     _safe_json,
     calculate_cost,
+    is_mocked_response,
     SYSTEM_PROMPT_TRIAGE,
     SYSTEM_PROMPT_ANALYSIS,
     SYSTEM_PROMPT_RESPONSE,
@@ -24,57 +27,130 @@ from app.providers.base import (
 _ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages"
 _ANTHROPIC_VERSION = "2023-06-01"
 
+_TOOL_TRIAGE: Dict[str, Any] = {
+    "name": "submit_triage",
+    "description": "Submit the triage classification for a support ticket.",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "severity": {
+                "type": "string",
+                "enum": ["low", "medium", "high", "critical"],
+            },
+            "category": {
+                "type": "string",
+                "enum": ["billing", "technical", "shipping", "account", "performance", "data", "integration", "mobile", "other"],
+            },
+            "urgency_score": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 10,
+            },
+            "escalation_required": {"type": "boolean"},
+            "affected_component": {"type": "string"},
+            "customer_sentiment": {
+                "type": "string",
+                "enum": ["frustrated", "neutral", "angry", "urgent"],
+            },
+        },
+        "required": ["severity", "category", "urgency_score", "escalation_required", "affected_component", "customer_sentiment"],
+    },
+}
+
+_TOOL_ANALYSIS: Dict[str, Any] = {
+    "name": "submit_analysis",
+    "description": "Submit the root cause analysis for a support ticket.",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "root_cause": {"type": "string"},
+            "customer_impact": {"type": "string"},
+            "affected_systems": {"type": "array", "items": {"type": "string"}},
+            "estimated_resolution_time": {"type": "string"},
+            "investigation_steps": {"type": "array", "items": {"type": "string"}},
+            "summary": {"type": "string"},
+        },
+        "required": ["root_cause", "customer_impact", "affected_systems", "estimated_resolution_time", "investigation_steps", "summary"],
+    },
+}
+
+_TOOL_RESPONSE: Dict[str, Any] = {
+    "name": "submit_response",
+    "description": "Submit the drafted customer response for a support ticket.",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "subject_line": {"type": "string"},
+            "response_body": {"type": "string"},
+            "recommended_action": {"type": "string"},
+            "follow_up_required": {"type": "boolean"},
+            "internal_notes": {"type": "string"},
+        },
+        "required": ["subject_line", "response_body", "recommended_action", "follow_up_required", "internal_notes"],
+    },
+}
+
 
 class AnthropicAdapter:
     name = "anthropic"
-    default_model = "claude-haiku-4-5"
+    default_model = "claude-opus-4-7"
 
-    async def run(self, request: RunRequest, context: str = "") -> AdapterResult:
+    async def stream(self, request: RunRequest, context: str = "") -> AsyncGenerator[StepEvent, None]:
         api_key = os.getenv("ANTHROPIC_API_KEY", "")
         if not api_key:
             raise ProviderError("ANTHROPIC_API_KEY not configured", status_code=503)
 
         model = request.model or self.default_model
-        steps: list[LLMStep] = []
 
-        triage_raw, p1, c1, d1 = await self._call(
+        triage_raw, p1, c1, d1, m1 = await self._call(
             api_key, model,
             system=SYSTEM_PROMPT_TRIAGE,
             user=build_triage_message(request),
+            tool=_TOOL_TRIAGE,
         )
         triage = _safe_json(triage_raw, {})
-        steps.append(LLMStep(
-            name="triage",
-            prompt_tokens=p1, completion_tokens=c1,
-            cost_usd=calculate_cost(model, p1, c1),
-            duration_ms=d1,
-        ))
+        yield StepEvent(name="triage", data=triage, prompt_tokens=p1, completion_tokens=c1,
+                        cost_usd=calculate_cost(model, p1, c1), duration_ms=d1, mocked=m1)
 
-        analysis_raw, p2, c2, d2 = await self._call(
+        analysis_raw, p2, c2, d2, m2 = await self._call(
             api_key, model,
             system=SYSTEM_PROMPT_ANALYSIS,
             user=build_analysis_message(request, triage, context),
+            tool=_TOOL_ANALYSIS,
         )
         analysis = _safe_json(analysis_raw, {})
-        steps.append(LLMStep(
-            name="analysis",
-            prompt_tokens=p2, completion_tokens=c2,
-            cost_usd=calculate_cost(model, p2, c2),
-            duration_ms=d2,
-        ))
+        yield StepEvent(name="analysis", data=analysis, prompt_tokens=p2, completion_tokens=c2,
+                        cost_usd=calculate_cost(model, p2, c2), duration_ms=d2, mocked=m2)
 
-        response_raw, p3, c3, d3 = await self._call(
+        response_raw, p3, c3, d3, m3 = await self._call(
             api_key, model,
             system=SYSTEM_PROMPT_RESPONSE,
             user=build_response_message(request, triage, analysis),
+            tool=_TOOL_RESPONSE,
         )
         response = _safe_json(response_raw, {})
-        steps.append(LLMStep(
-            name="response",
-            prompt_tokens=p3, completion_tokens=c3,
-            cost_usd=calculate_cost(model, p3, c3),
-            duration_ms=d3,
-        ))
+        yield StepEvent(name="response", data=response, prompt_tokens=p3, completion_tokens=c3,
+                        cost_usd=calculate_cost(model, p3, c3), duration_ms=d3, mocked=m3)
+
+    async def run(self, request: RunRequest, context: str = "") -> AdapterResult:
+        steps: list[LLMStep] = []
+        step_data: dict[str, dict] = {}
+        mocked_any = False
+        async for event in self.stream(request, context):
+            steps.append(LLMStep(
+                name=event.name,
+                prompt_tokens=event.prompt_tokens,
+                completion_tokens=event.completion_tokens,
+                cost_usd=event.cost_usd,
+                duration_ms=event.duration_ms,
+            ))
+            step_data[event.name] = event.data
+            if event.mocked:
+                mocked_any = True
+
+        triage = step_data.get("triage", {})
+        analysis = step_data.get("analysis", {})
+        response = step_data.get("response", {})
 
         output = OutputEnvelope(
             severity=triage.get("severity", "medium"),
@@ -89,18 +165,24 @@ class AnthropicAdapter:
             steps=steps,
             total_tokens=total_tokens,
             cost_usd=round(sum(s.cost_usd for s in steps), 6),
+            mocked=mocked_any,
         )
 
     async def _call(
-        self, api_key: str, model: str, system: str, user: str
-    ) -> Tuple[str, int, int, int]:
-        """Returns (content, prompt_tokens, completion_tokens, duration_ms)."""
-        payload = {
+        self, api_key: str, model: str, system: str, user: str,
+        tool: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[str, int, int, int, bool]:
+        """Returns (content_json, prompt_tokens, completion_tokens, duration_ms, mocked)."""
+        payload: Dict[str, Any] = {
             "model": model,
             "max_tokens": 2048,
             "system": system,
             "messages": [{"role": "user", "content": user}],
         }
+        if tool:
+            payload["tools"] = [tool]
+            payload["tool_choice"] = {"type": "tool", "name": tool["name"]}
+
         t0 = time.monotonic()
         async with httpx.AsyncClient(timeout=60.0) as client:
             resp = await client.post(
@@ -120,6 +202,22 @@ class AnthropicAdapter:
             raise ProviderError(f"Anthropic returned {resp.status_code}: {resp.text}", status_code=502)
 
         data = resp.json()
-        content = data["content"][0]["text"]
         usage = data.get("usage", {})
-        return content, usage.get("input_tokens", 0), usage.get("output_tokens", 0), duration_ms
+
+        if tool:
+            for block in data.get("content", []):
+                if block.get("type") == "tool_use":
+                    content = json.dumps(block["input"])
+                    break
+            else:
+                content = "{}"
+        else:
+            content = data["content"][0]["text"]
+
+        return (
+            content,
+            usage.get("input_tokens", 0),
+            usage.get("output_tokens", 0),
+            duration_ms,
+            is_mocked_response(resp.headers),
+        )

--- a/llm-simulation-demo/backend/app/providers/base.py
+++ b/llm-simulation-demo/backend/app/providers/base.py
@@ -20,6 +20,7 @@ class AdapterResult:
     steps: List[LLMStep] = field(default_factory=list)
     total_tokens: int = 0
     cost_usd: float = 0.0
+    mocked: bool = False
 
 
 @runtime_checkable
@@ -34,16 +35,16 @@ class ProviderAdapter(Protocol):
 # Per-model pricing in USD per 1M tokens (input_price, output_price)
 MODEL_PRICING: Dict[str, Tuple[float, float]] = {
     # OpenAI (see https://platform.openai.com/docs/models )
+    "gpt-5.5":                  (5.00,  30.00),
     "gpt-5.4-mini":             (0.75,   4.50),
-    "gpt-5.4":                  (2.50,  15.00),
     "gpt-5.4-nano":             (0.20,   1.25),
     "gpt-4.1-mini":             (0.40,   1.60),
     "gpt-4.1":                  (2.00,   8.00),
     "gpt-4o-mini":              (0.15,   0.60),
     # Anthropic
-    "claude-haiku-4-5":         (0.80,   4.00),
-    "claude-sonnet-4-5":        (3.00,  15.00),
-    "claude-opus-4-5":          (15.00, 75.00),
+    "claude-haiku-4-5-20251001": (0.80,   4.00),
+    "claude-sonnet-4-6":         (3.00,  15.00),
+    "claude-opus-4-7":           (15.00, 75.00),
     # Gemini
     "gemini-flash-latest":      (0.10,   0.40),
     "gemini-flash-lite-latest": (0.075,  0.30),
@@ -268,3 +269,22 @@ def _safe_json(raw: str, default: dict) -> dict:
         return json.loads(raw)
     except Exception:
         return default
+
+
+@dataclass
+class StepEvent:
+    name: str
+    data: dict
+    prompt_tokens: int
+    completion_tokens: int
+    cost_usd: float
+    duration_ms: int
+    mocked: bool = False
+
+
+def is_mocked_response(headers) -> bool:
+    """True if proxymock served the response (it stamps X-Speedscale-* headers)."""
+    for k in headers.keys():
+        if k.lower().startswith("x-speedscale"):
+            return True
+    return False

--- a/llm-simulation-demo/backend/app/providers/gemini_adapter.py
+++ b/llm-simulation-demo/backend/app/providers/gemini_adapter.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import time
-from typing import Tuple
+from typing import AsyncGenerator, Tuple
 
 import httpx
 import os
@@ -11,8 +11,10 @@ from app.models.result import LLMStep, OutputEnvelope
 from app.providers.base import (
     AdapterResult,
     ProviderError,
+    StepEvent,
     _safe_json,
     calculate_cost,
+    is_mocked_response,
     SYSTEM_PROMPT_TRIAGE,
     SYSTEM_PROMPT_ANALYSIS,
     SYSTEM_PROMPT_RESPONSE,
@@ -26,54 +28,61 @@ _GEMINI_API_BASE = "https://generativelanguage.googleapis.com/v1beta/models"
 
 class GeminiAdapter:
     name = "gemini"
-    default_model = "gemini-flash-latest"
+    default_model = "gemini-pro-latest"
 
-    async def run(self, request: RunRequest, context: str = "") -> AdapterResult:
+    async def stream(self, request: RunRequest, context: str = "") -> AsyncGenerator[StepEvent, None]:
         api_key = os.getenv("GEMINI_API_KEY", "")
         if not api_key:
             raise ProviderError("GEMINI_API_KEY not configured", status_code=503)
 
         model = request.model or self.default_model
-        steps: list[LLMStep] = []
 
-        triage_raw, p1, c1, d1 = await self._call(
+        triage_raw, p1, c1, d1, m1 = await self._call(
             api_key, model,
             system=SYSTEM_PROMPT_TRIAGE,
             user=build_triage_message(request),
         )
         triage = _safe_json(triage_raw, {})
-        steps.append(LLMStep(
-            name="triage",
-            prompt_tokens=p1, completion_tokens=c1,
-            cost_usd=calculate_cost(model, p1, c1),
-            duration_ms=d1,
-        ))
+        yield StepEvent(name="triage", data=triage, prompt_tokens=p1, completion_tokens=c1,
+                        cost_usd=calculate_cost(model, p1, c1), duration_ms=d1, mocked=m1)
 
-        analysis_raw, p2, c2, d2 = await self._call(
+        analysis_raw, p2, c2, d2, m2 = await self._call(
             api_key, model,
             system=SYSTEM_PROMPT_ANALYSIS,
             user=build_analysis_message(request, triage, context),
         )
         analysis = _safe_json(analysis_raw, {})
-        steps.append(LLMStep(
-            name="analysis",
-            prompt_tokens=p2, completion_tokens=c2,
-            cost_usd=calculate_cost(model, p2, c2),
-            duration_ms=d2,
-        ))
+        yield StepEvent(name="analysis", data=analysis, prompt_tokens=p2, completion_tokens=c2,
+                        cost_usd=calculate_cost(model, p2, c2), duration_ms=d2, mocked=m2)
 
-        response_raw, p3, c3, d3 = await self._call(
+        response_raw, p3, c3, d3, m3 = await self._call(
             api_key, model,
             system=SYSTEM_PROMPT_RESPONSE,
             user=build_response_message(request, triage, analysis),
         )
         response = _safe_json(response_raw, {})
-        steps.append(LLMStep(
-            name="response",
-            prompt_tokens=p3, completion_tokens=c3,
-            cost_usd=calculate_cost(model, p3, c3),
-            duration_ms=d3,
-        ))
+        yield StepEvent(name="response", data=response, prompt_tokens=p3, completion_tokens=c3,
+                        cost_usd=calculate_cost(model, p3, c3), duration_ms=d3, mocked=m3)
+
+    async def run(self, request: RunRequest, context: str = "") -> AdapterResult:
+        steps: list[LLMStep] = []
+        step_data: dict[str, dict] = {}
+        mocked_any = False
+        async for event in self.stream(request, context):
+            steps.append(LLMStep(
+                name=event.name,
+                prompt_tokens=event.prompt_tokens,
+                completion_tokens=event.completion_tokens,
+                cost_usd=event.cost_usd,
+                duration_ms=event.duration_ms,
+            ))
+            step_data[event.name] = event.data
+            if event.mocked:
+                mocked_any = True
+
+        triage = step_data.get("triage", {})
+        analysis = step_data.get("analysis", {})
+        response = step_data.get("response", {})
 
         output = OutputEnvelope(
             severity=triage.get("severity", "medium"),
@@ -88,12 +97,13 @@ class GeminiAdapter:
             steps=steps,
             total_tokens=total_tokens,
             cost_usd=round(sum(s.cost_usd for s in steps), 6),
+            mocked=mocked_any,
         )
 
     async def _call(
         self, api_key: str, model: str, system: str, user: str
-    ) -> Tuple[str, int, int, int]:
-        """Returns (content, prompt_tokens, completion_tokens, duration_ms)."""
+    ) -> Tuple[str, int, int, int, bool]:
+        """Returns (content, prompt_tokens, completion_tokens, duration_ms, mocked)."""
         url = f"{_GEMINI_API_BASE}/{model}:generateContent?key={api_key}"
         payload = {
             "system_instruction": {"parts": [{"text": system}]},
@@ -119,4 +129,4 @@ class GeminiAdapter:
         usage = data.get("usageMetadata", {})
         prompt_tokens = usage.get("promptTokenCount", 0)
         completion_tokens = usage.get("candidatesTokenCount", 0)
-        return content, prompt_tokens, completion_tokens, duration_ms
+        return content, prompt_tokens, completion_tokens, duration_ms, is_mocked_response(resp.headers)

--- a/llm-simulation-demo/backend/app/providers/openai_adapter.py
+++ b/llm-simulation-demo/backend/app/providers/openai_adapter.py
@@ -1,17 +1,20 @@
 from __future__ import annotations
 
 import time
-from typing import Tuple
+from typing import AsyncGenerator, Tuple
 
 import httpx
+import os
 
 from app.models.request import RunRequest
 from app.models.result import LLMStep, OutputEnvelope
 from app.providers.base import (
     AdapterResult,
     ProviderError,
+    StepEvent,
     _safe_json,
     calculate_cost,
+    is_mocked_response,
     SYSTEM_PROMPT_TRIAGE,
     SYSTEM_PROMPT_ANALYSIS,
     SYSTEM_PROMPT_RESPONSE,
@@ -19,80 +22,77 @@ from app.providers.base import (
     build_analysis_message,
     build_response_message,
 )
-import os
 
 _OPENAI_API_URL = "https://api.openai.com/v1/chat/completions"
 
 
 class OpenAIAdapter:
     name = "openai"
-    default_model = "gpt-5.4-mini"
+    default_model = "gpt-5.5"
+    _api_key_env = "OPENAI_API_KEY"
+    _api_base_url = _OPENAI_API_URL
 
-    async def run(self, request: RunRequest, context: str = "") -> AdapterResult:
-        api_key = os.getenv("OPENAI_API_KEY", "")
+    async def stream(self, request: RunRequest, context: str = "") -> AsyncGenerator[StepEvent, None]:
+        api_key = os.getenv(self._api_key_env, "")
         if not api_key:
-            raise ProviderError("OPENAI_API_KEY not configured", status_code=503)
+            raise ProviderError(f"{self._api_key_env} not configured", status_code=503)
 
         model = request.model or self.default_model
-        steps: list[LLMStep] = []
 
-        triage_raw, p1, c1, d1 = await self._call(
-            api_key,
-            model,
+        triage_raw, p1, c1, d1, m1 = await self._call(
+            api_key, model,
             system=SYSTEM_PROMPT_TRIAGE,
             user=build_triage_message(request),
+            base_url=self._api_base_url,
         )
         triage = _safe_json(triage_raw, {})
-        steps.append(
-            LLMStep(
-                name="triage",
-                prompt_tokens=p1,
-                completion_tokens=c1,
-                cost_usd=calculate_cost(model, p1, c1),
-                duration_ms=d1,
-            )
-        )
+        yield StepEvent(name="triage", data=triage, prompt_tokens=p1, completion_tokens=c1,
+                        cost_usd=calculate_cost(model, p1, c1), duration_ms=d1, mocked=m1)
 
-        analysis_raw, p2, c2, d2 = await self._call(
-            api_key,
-            model,
+        analysis_raw, p2, c2, d2, m2 = await self._call(
+            api_key, model,
             system=SYSTEM_PROMPT_ANALYSIS,
             user=build_analysis_message(request, triage, context),
+            base_url=self._api_base_url,
         )
         analysis = _safe_json(analysis_raw, {})
-        steps.append(
-            LLMStep(
-                name="analysis",
-                prompt_tokens=p2,
-                completion_tokens=c2,
-                cost_usd=calculate_cost(model, p2, c2),
-                duration_ms=d2,
-            )
-        )
+        yield StepEvent(name="analysis", data=analysis, prompt_tokens=p2, completion_tokens=c2,
+                        cost_usd=calculate_cost(model, p2, c2), duration_ms=d2, mocked=m2)
 
-        response_raw, p3, c3, d3 = await self._call(
-            api_key,
-            model,
+        response_raw, p3, c3, d3, m3 = await self._call(
+            api_key, model,
             system=SYSTEM_PROMPT_RESPONSE,
             user=build_response_message(request, triage, analysis),
+            base_url=self._api_base_url,
         )
         response = _safe_json(response_raw, {})
-        steps.append(
-            LLMStep(
-                name="response",
-                prompt_tokens=p3,
-                completion_tokens=c3,
-                cost_usd=calculate_cost(model, p3, c3),
-                duration_ms=d3,
-            )
-        )
+        yield StepEvent(name="response", data=response, prompt_tokens=p3, completion_tokens=c3,
+                        cost_usd=calculate_cost(model, p3, c3), duration_ms=d3, mocked=m3)
+
+    async def run(self, request: RunRequest, context: str = "") -> AdapterResult:
+        steps: list[LLMStep] = []
+        step_data: dict[str, dict] = {}
+        mocked_any = False
+        async for event in self.stream(request, context):
+            steps.append(LLMStep(
+                name=event.name,
+                prompt_tokens=event.prompt_tokens,
+                completion_tokens=event.completion_tokens,
+                cost_usd=event.cost_usd,
+                duration_ms=event.duration_ms,
+            ))
+            step_data[event.name] = event.data
+            if event.mocked:
+                mocked_any = True
+
+        triage = step_data.get("triage", {})
+        analysis = step_data.get("analysis", {})
+        response = step_data.get("response", {})
 
         output = OutputEnvelope(
             severity=triage.get("severity", "medium"),
             summary=analysis.get("summary", "Unable to analyze ticket."),
-            recommended_action=response.get(
-                "recommended_action", "Escalate to L2 engineering."
-            ),
+            recommended_action=response.get("recommended_action", "Escalate to L2 engineering."),
             root_cause=analysis.get("root_cause"),
             response_draft=response.get("response_body"),
         )
@@ -102,6 +102,7 @@ class OpenAIAdapter:
             steps=steps,
             total_tokens=total_tokens,
             cost_usd=round(sum(s.cost_usd for s in steps), 6),
+            mocked=mocked_any,
         )
 
     async def _call(
@@ -112,9 +113,15 @@ class OpenAIAdapter:
         user: str,
         base_url: str = _OPENAI_API_URL,
         auth_header: str | None = None,
-    ) -> Tuple[str, int, int, int]:
-        """Returns (content, prompt_tokens, completion_tokens, duration_ms)."""
-        headers = {"Authorization": f"Bearer {auth_header or api_key}"}
+    ) -> Tuple[str, int, int, int, bool]:
+        """Returns (content, prompt_tokens, completion_tokens, duration_ms, mocked)."""
+        headers = {
+            "Authorization": f"Bearer {auth_header or api_key}",
+            # Avoid brotli so proxymock can faithfully replay the response.
+            # See linear S-10993 — the responder serves a decoded body but keeps
+            # Content-Encoding: br, which makes httpx (with brotli installed) fail.
+            "Accept-Encoding": "gzip",
+        }
         payload = {
             "model": model,
             "messages": [
@@ -122,7 +129,6 @@ class OpenAIAdapter:
                 {"role": "user", "content": user},
             ],
             "response_format": {"type": "json_object"},
-            "temperature": 0.2,
             "max_completion_tokens": 2048,
         }
         t0 = time.monotonic()
@@ -145,4 +151,5 @@ class OpenAIAdapter:
             usage.get("prompt_tokens", 0),
             usage.get("completion_tokens", 0),
             duration_ms,
+            is_mocked_response(resp.headers),
         )

--- a/llm-simulation-demo/backend/app/providers/xai_adapter.py
+++ b/llm-simulation-demo/backend/app/providers/xai_adapter.py
@@ -1,22 +1,5 @@
 from __future__ import annotations
 
-import os
-from typing import Tuple
-
-from app.models.request import RunRequest
-from app.providers.base import (
-    AdapterResult,
-    ProviderError,
-    _safe_json,
-    calculate_cost,
-    SYSTEM_PROMPT_TRIAGE,
-    SYSTEM_PROMPT_ANALYSIS,
-    SYSTEM_PROMPT_RESPONSE,
-    build_triage_message,
-    build_analysis_message,
-    build_response_message,
-)
-from app.models.result import LLMStep, OutputEnvelope
 from app.providers.openai_adapter import OpenAIAdapter
 
 _XAI_API_URL = "https://api.x.ai/v1/chat/completions"
@@ -26,69 +9,6 @@ class XAIAdapter(OpenAIAdapter):
     """Grok (xAI) adapter — uses the same OpenAI-compatible API at a different base URL."""
 
     name = "xai"
-    default_model = "grok-4-1-fast-non-reasoning"
-
-    async def run(self, request: RunRequest, context: str = "") -> AdapterResult:
-        api_key = os.getenv("XAI_API_KEY", "")
-        if not api_key:
-            raise ProviderError("XAI_API_KEY not configured", status_code=503)
-
-        model = request.model or self.default_model
-        steps: list[LLMStep] = []
-
-        triage_raw, p1, c1, d1 = await self._call(
-            api_key, model,
-            system=SYSTEM_PROMPT_TRIAGE,
-            user=build_triage_message(request),
-            base_url=_XAI_API_URL,
-        )
-        triage = _safe_json(triage_raw, {})
-        steps.append(LLMStep(
-            name="triage",
-            prompt_tokens=p1, completion_tokens=c1,
-            cost_usd=calculate_cost(model, p1, c1),
-            duration_ms=d1,
-        ))
-
-        analysis_raw, p2, c2, d2 = await self._call(
-            api_key, model,
-            system=SYSTEM_PROMPT_ANALYSIS,
-            user=build_analysis_message(request, triage, context),
-            base_url=_XAI_API_URL,
-        )
-        analysis = _safe_json(analysis_raw, {})
-        steps.append(LLMStep(
-            name="analysis",
-            prompt_tokens=p2, completion_tokens=c2,
-            cost_usd=calculate_cost(model, p2, c2),
-            duration_ms=d2,
-        ))
-
-        response_raw, p3, c3, d3 = await self._call(
-            api_key, model,
-            system=SYSTEM_PROMPT_RESPONSE,
-            user=build_response_message(request, triage, analysis),
-            base_url=_XAI_API_URL,
-        )
-        response = _safe_json(response_raw, {})
-        steps.append(LLMStep(
-            name="response",
-            prompt_tokens=p3, completion_tokens=c3,
-            cost_usd=calculate_cost(model, p3, c3),
-            duration_ms=d3,
-        ))
-
-        output = OutputEnvelope(
-            severity=triage.get("severity", "medium"),
-            summary=analysis.get("summary", "Unable to analyze ticket."),
-            recommended_action=response.get("recommended_action", "Escalate to L2 engineering."),
-            root_cause=analysis.get("root_cause"),
-            response_draft=response.get("response_body"),
-        )
-        total_tokens = sum(s.prompt_tokens + s.completion_tokens for s in steps)
-        return AdapterResult(
-            output=output,
-            steps=steps,
-            total_tokens=total_tokens,
-            cost_usd=round(sum(s.cost_usd for s in steps), 6),
-        )
+    default_model = "grok-4.20-0309-non-reasoning"
+    _api_key_env = "XAI_API_KEY"
+    _api_base_url = _XAI_API_URL

--- a/llm-simulation-demo/backend/tests/test_providers.py
+++ b/llm-simulation-demo/backend/tests/test_providers.py
@@ -193,8 +193,10 @@ class TestOpenAIAdapterRun:
 # ---------------------------------------------------------------------------
 
 def _anthropic_response(content: str, input_tokens: int = 100, output_tokens: int = 50) -> httpx.Response:
+    # Adapter now forces tool_use for structured output, so the response
+    # body must carry the tool result under `content[].input`, not `content[].text`.
     return httpx.Response(200, json={
-        "content": [{"text": content}],
+        "content": [{"type": "tool_use", "input": json.loads(content)}],
         "usage": {"input_tokens": input_tokens, "output_tokens": output_tokens},
     })
 

--- a/llm-simulation-demo/frontend/package-lock.json
+++ b/llm-simulation-demo/frontend/package-lock.json
@@ -5773,7 +5773,6 @@
       "version": "8.5.14",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
       "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",

--- a/llm-simulation-demo/frontend/package-lock.json
+++ b/llm-simulation-demo/frontend/package-lock.json
@@ -6987,9 +6987,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/llm-simulation-demo/frontend/src/app/api/[...path]/route.ts
+++ b/llm-simulation-demo/frontend/src/app/api/[...path]/route.ts
@@ -23,11 +23,24 @@ async function handler(
   }
 
   const upstream = await fetch(target, init);
-  const body = await upstream.text();
+  const upstreamContentType = upstream.headers.get("content-type") ?? "application/json";
 
+  // Stream SSE responses directly without buffering.
+  if (upstreamContentType.includes("text/event-stream")) {
+    return new NextResponse(upstream.body, {
+      status: upstream.status,
+      headers: {
+        "content-type": upstreamContentType,
+        "cache-control": "no-cache",
+        "x-accel-buffering": "no",
+      },
+    });
+  }
+
+  const body = await upstream.text();
   return new NextResponse(body, {
     status: upstream.status,
-    headers: { "content-type": upstream.headers.get("content-type") ?? "application/json" },
+    headers: { "content-type": upstreamContentType },
   });
 }
 

--- a/llm-simulation-demo/frontend/src/app/costs/page.tsx
+++ b/llm-simulation-demo/frontend/src/app/costs/page.tsx
@@ -1,0 +1,269 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { listRuns } from "@/lib/api";
+import type { RunResult } from "@/lib/types";
+
+const PROVIDER_DISPLAY: Record<string, string> = {
+  openai: "OpenAI",
+  anthropic: "Anthropic",
+  gemini: "Gemini",
+  xai: "xAI / Grok",
+};
+
+function fmt$(n: number): string {
+  if (n === 0) return "$0.00";
+  if (n < 0.01) return `$${n.toFixed(4)}`;
+  if (n < 1) return `$${n.toFixed(3)}`;
+  return `$${n.toFixed(2)}`;
+}
+
+function fmtLarge(n: number): string {
+  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `$${(n / 1_000).toFixed(0)}K`;
+  return fmt$(n);
+}
+
+export default function CostsPage() {
+  const [runs, setRuns] = useState<RunResult[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [runsPerDay, setRunsPerDay] = useState(10000);
+
+  useEffect(() => {
+    function refresh() {
+      listRuns(500)
+        .then((d) => setRuns(d.runs))
+        .catch(() => {})
+        .finally(() => setLoading(false));
+    }
+    refresh();
+    function onRunComplete() {
+      // Refresh from backend whenever a new run completes elsewhere in the app.
+      refresh();
+    }
+    window.addEventListener("run-complete", onRunComplete);
+    return () => window.removeEventListener("run-complete", onRunComplete);
+  }, []);
+
+  const liveRuns = runs.filter((r) => !r.mocked);
+  const mockedRuns = runs.filter((r) => r.mocked);
+  const liveCost = liveRuns.reduce((s, r) => s + r.cost_usd, 0);
+  const savedCost = mockedRuns.reduce((s, r) => s + r.cost_usd, 0);
+  const totalTokens = runs.reduce((s, r) => s + r.total_tokens, 0);
+  const totalCalls = runs.length * 3;
+  // Use live runs for scale projection — they reflect real-world cost
+  const baselineRuns = liveRuns.length > 0 ? liveRuns : runs;
+  const avgPerTicket = baselineRuns.length > 0
+    ? baselineRuns.reduce((s, r) => s + r.cost_usd, 0) / baselineRuns.length
+    : 0;
+
+  // Group by provider and by model
+  const byProvider: Record<string, { cost: number; tokens: number; count: number }> = {};
+  const byModel: Record<string, { provider: string; cost: number; tokens: number; count: number; mocked: boolean }> = {};
+  for (const run of runs) {
+    if (!byProvider[run.provider]) byProvider[run.provider] = { cost: 0, tokens: 0, count: 0 };
+    byProvider[run.provider].cost += run.cost_usd;
+    byProvider[run.provider].tokens += run.total_tokens;
+    byProvider[run.provider].count += 1;
+
+    // Key by model+mode so live and mocked rows show separately
+    const key = `${run.model}::${run.mocked ? "mock" : "live"}`;
+    if (!byModel[key]) byModel[key] = { provider: run.provider, cost: 0, tokens: 0, count: 0, mocked: !!run.mocked };
+    byModel[key].cost += run.cost_usd;
+    byModel[key].tokens += run.total_tokens;
+    byModel[key].count += 1;
+  }
+
+  const dailyCost = avgPerTicket * runsPerDay;
+  const monthlyCost = dailyCost * 30;
+  const annualCost = dailyCost * 365;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">Costs</h1>
+        <p className="mt-1 text-sm" style={{ color: "var(--text-muted)" }}>
+          All LLM spend so far, served from the backend run store.
+        </p>
+      </div>
+
+      {loading && (
+        <p className="text-sm animate-pulse" style={{ color: "var(--text-muted)" }}>
+          Loading…
+        </p>
+      )}
+
+      {!loading && runs.length === 0 && (
+        <p className="text-sm" style={{ color: "var(--text-muted)" }}>
+          No runs yet.{" "}
+          <a href="/" className="underline">
+            Analyze a ticket
+          </a>{" "}
+          to see costs accumulate.
+        </p>
+      )}
+
+      {runs.length > 0 && (
+        <>
+          {/* Totals: live spend vs simulated savings */}
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div className="rounded-xl p-5 text-center space-y-1" style={{ background: "#ef444411", border: "1px solid #ef444433" }}>
+              <p className="text-xs uppercase tracking-wider" style={{ color: "#ef4444" }}>Live spend (billed)</p>
+              <p className="text-4xl font-bold leading-none font-mono" style={{ color: "#ef4444" }}>{fmt$(liveCost)}</p>
+              <p className="text-xs" style={{ color: "var(--text-muted)" }}>{liveRuns.length} tickets · {liveRuns.length * 3} LLM calls</p>
+            </div>
+            <div className="rounded-xl p-5 text-center space-y-1" style={{ background: "#10b98111", border: "1px solid #10b98133" }}>
+              <p className="text-xs uppercase tracking-wider" style={{ color: "#10b981" }}>Saved by simulation</p>
+              <p className="text-4xl font-bold leading-none font-mono" style={{ color: "#10b981" }}>{fmt$(savedCost)}</p>
+              <p className="text-xs" style={{ color: "var(--text-muted)" }}>{mockedRuns.length} tickets · {mockedRuns.length * 3} mocked calls</p>
+            </div>
+            <div className="rounded-xl p-5 text-center space-y-1" style={{ background: "var(--surface)", border: "1px solid var(--border)" }}>
+              <p className="text-xs uppercase tracking-wider" style={{ color: "var(--text-muted)" }}>Tokens · avg/ticket</p>
+              <p className="text-4xl font-bold leading-none font-mono">{totalTokens.toLocaleString()}</p>
+              <p className="text-xs" style={{ color: "var(--text-muted)" }}>{fmt$(avgPerTicket)} per ticket {liveRuns.length === 0 ? "(simulated baseline)" : "(live baseline)"}</p>
+            </div>
+          </div>
+
+          {/* Per-model breakdown */}
+          <div className="rounded-xl p-5 space-y-3" style={{ background: "var(--surface)", border: "1px solid var(--border)" }}>
+            <p className="text-sm font-bold">By model</p>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr style={{ color: "var(--text-muted)" }} className="text-left text-xs uppercase tracking-wider">
+                    <th className="py-2 pr-4">Model</th>
+                    <th className="py-2 pr-4">Provider</th>
+                    <th className="py-2 pr-4">Mode</th>
+                    <th className="py-2 pr-4 text-right">Tickets</th>
+                    <th className="py-2 pr-4 text-right">Tokens</th>
+                    <th className="py-2 pr-4 text-right">Avg / ticket</th>
+                    <th className="py-2 text-right">Total</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {Object.entries(byModel)
+                    .sort((a, b) => b[1].cost - a[1].cost)
+                    .map(([key, info]) => {
+                      const model = key.split("::")[0];
+                      const color = info.mocked ? "#10b981" : "#ef4444";
+                      return (
+                        <tr key={key} className="border-t" style={{ borderColor: "var(--border)" }}>
+                          <td className="py-2 pr-4 font-mono">{model}</td>
+                          <td className="py-2 pr-4" style={{ color: "var(--text-muted)" }}>
+                            {PROVIDER_DISPLAY[info.provider] ?? info.provider}
+                          </td>
+                          <td className="py-2 pr-4">
+                            <span
+                              className="text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full"
+                              style={{ background: `${color}22`, color, border: `1px solid ${color}44` }}
+                            >
+                              {info.mocked ? "Simulated" : "Live"}
+                            </span>
+                          </td>
+                          <td className="py-2 pr-4 text-right font-mono">{info.count}</td>
+                          <td className="py-2 pr-4 text-right font-mono" style={{ color: "var(--text-muted)" }}>
+                            {info.tokens.toLocaleString()}
+                          </td>
+                          <td className="py-2 pr-4 text-right font-mono">{fmt$(info.cost / info.count)}</td>
+                          <td className="py-2 text-right font-mono font-bold" style={{ color }}>
+                            {fmt$(info.cost)}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          {/* Per-provider breakdown */}
+          <div className="rounded-xl p-5 space-y-3" style={{ background: "var(--surface)", border: "1px solid var(--border)" }}>
+            <p className="text-sm font-bold">By provider</p>
+            <div className="space-y-2">
+              {Object.entries(byProvider)
+                .sort((a, b) => b[1].cost - a[1].cost)
+                .map(([prov, info]) => {
+                  const grandTotal = liveCost + savedCost;
+                  const pct = grandTotal > 0 ? (info.cost / grandTotal) * 100 : 0;
+                  return (
+                    <div key={prov} className="flex items-center gap-3 text-xs">
+                      <span className="w-28 font-medium">{PROVIDER_DISPLAY[prov] ?? prov}</span>
+                      <div className="flex-1 h-2 rounded-full overflow-hidden" style={{ background: "var(--surface2)" }}>
+                        <div className="h-full rounded-full" style={{ width: `${pct}%`, background: "var(--accent)" }} />
+                      </div>
+                      <span className="w-16 text-right font-mono" style={{ color: "var(--text-muted)" }}>
+                        {info.count} tkt
+                      </span>
+                      <span className="w-24 text-right font-mono font-bold" style={{ color: "#ef4444" }}>
+                        {fmt$(info.cost)}
+                      </span>
+                    </div>
+                  );
+                })}
+            </div>
+          </div>
+
+          {/* Cost at scale */}
+          <div className="rounded-xl p-5 space-y-4" style={{ background: "var(--surface)", border: "1px solid var(--border)" }}>
+            <div>
+              <p className="text-sm font-bold">Cost at scale</p>
+              <p className="text-xs mt-0.5" style={{ color: "var(--text-muted)" }}>
+                Projected from {fmt$(avgPerTicket)} avg / ticket
+                {liveRuns.length === 0 && " — no live runs yet, using simulated cost as a stand-in"}
+              </p>
+            </div>
+
+            <div className="space-y-1.5">
+              <div className="flex items-center justify-between text-xs">
+                <label style={{ color: "var(--text-muted)" }}>Support tickets / day</label>
+                <span className="font-semibold">{runsPerDay.toLocaleString()}</span>
+              </div>
+              <input
+                type="range"
+                min={1000}
+                max={100000}
+                step={1000}
+                value={runsPerDay}
+                onChange={(e) => setRunsPerDay(Number(e.target.value))}
+                className="w-full"
+              />
+              <div className="flex justify-between text-xs" style={{ color: "var(--text-muted)" }}>
+                <span>1K startup</span>
+                <span>10K growing</span>
+                <span>100K enterprise</span>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div className="rounded-xl p-4 text-center space-y-1" style={{ background: "#ef444411", border: "1px solid #ef444433" }}>
+                <p className="text-xs uppercase tracking-wider" style={{ color: "#ef4444" }}>Annual LLM spend</p>
+                <p className="text-3xl font-bold leading-none" style={{ color: "#ef4444" }}>{fmtLarge(annualCost)}</p>
+                <p className="text-xs" style={{ color: "var(--text-muted)" }}>
+                  {fmt$(dailyCost)}/day · {fmtLarge(monthlyCost)}/mo
+                </p>
+              </div>
+              <div className="rounded-xl p-4 text-center space-y-1" style={{ background: "#10b98111", border: "1px solid #10b98133" }}>
+                <p className="text-xs uppercase tracking-wider" style={{ color: "#10b981" }}>With simulation</p>
+                <p className="text-3xl font-bold leading-none" style={{ color: "#10b981" }}>$0</p>
+                <p className="text-xs font-semibold" style={{ color: "#10b981" }}>
+                  Save {fmtLarge(annualCost)} / year
+                </p>
+              </div>
+            </div>
+
+            <div className="rounded-lg p-3 text-xs space-y-1" style={{ background: "var(--surface2)", border: "1px solid var(--border)", color: "var(--text-muted)" }}>
+              <p>
+                <strong style={{ color: "var(--text)" }}>How simulation eliminates this cost:</strong>
+              </p>
+              <p>
+                Speedscale captures the exact traffic pattern from this run — real tickets, real LLM responses — and
+                replays it at any scale without calling the API. Your support pipeline gets realistic responses in
+                testing and load scenarios for $0.
+              </p>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/llm-simulation-demo/frontend/src/app/page.tsx
+++ b/llm-simulation-demo/frontend/src/app/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { runTask, getProviders } from "@/lib/api";
-import type { ProviderInfo, RunResult } from "@/lib/types";
+import { streamTask, runTask, getProviders, listRuns } from "@/lib/api";
+import type { LLMStep, ProviderInfo, RunResult, TicketRunState, ToolCallRecord } from "@/lib/types";
 import { SeverityBadge } from "@/components/SeverityBadge";
 
 // ── 20 sample tickets ───────────────────────────────────────────────────────
@@ -136,7 +136,6 @@ const SEVERITY_COLORS: Record<string, string> = {
   critical: "#ef4444",
 };
 
-// ── Pricing note shown in the savings estimator ─────────────────────────────
 const PROVIDER_DISPLAY: Record<string, string> = {
   openai: "OpenAI",
   anthropic: "Anthropic",
@@ -148,6 +147,19 @@ function fmt$(n: number): string {
   if (n === 0) return "$0.00";
   if (n < 0.01) return `$${n.toFixed(4)}`;
   return `$${n.toFixed(2)}`;
+}
+
+// Shorten verbose model IDs so they fit on ticket buttons.
+function shortModel(m: string): string {
+  if (!m) return "";
+  if (m.startsWith("claude-")) {
+    if (m.includes("opus")) return "opus-4.7";
+    if (m.includes("sonnet")) return "sonnet-4.6";
+    if (m.includes("haiku")) return "haiku-4.5";
+  }
+  if (m.startsWith("gemini-")) return m.replace("gemini-", "").replace("-latest", "");
+  if (m.startsWith("grok-")) return m.replace("grok-", "").replace("-non-reasoning", "-nr").replace("-reasoning", "-rsn");
+  return m;
 }
 
 // ── Small UI primitives ─────────────────────────────────────────────────────
@@ -200,54 +212,102 @@ function ToolCard({ title, data }: { title: string; data: Record<string, unknown
   );
 }
 
-// ── Single-run result panel ─────────────────────────────────────────────────
+// ── Streaming single-ticket result panel ────────────────────────────────────
 
-function ResultPanel({ result }: { result: RunResult }) {
-  const order = result.tool_calls.find((t) => t.name === "lookup_order");
-  const policy = result.tool_calls.find((t) => t.name === "lookup_policy");
+function StreamingResultPanel({ state }: { state: TicketRunState }) {
   const [expanded, setExpanded] = useState(false);
+  const color = state.severity ? SEVERITY_COLORS[state.severity] : undefined;
+  const severityBg = color ? `${color}11` : "var(--surface)";
 
-  const severityBg: Record<string, string> = {
-    low: "#10b98111",
-    medium: "#f59e0b11",
-    high: "#f9731611",
-    critical: "#ef444411",
-  };
+  const stepLabel: Record<string, string> = { triage: "Classifying…", analysis: "Analyzing root cause…", response: "Drafting response…" };
 
   return (
     <div className="space-y-4">
-      {/* Header row: severity + cost */}
+      {/* Prominent model header */}
       <div
-        className="rounded-xl p-5 space-y-4"
-        style={{ background: severityBg[result.output.severity] ?? "var(--surface)", border: "1px solid var(--border)" }}
+        className="rounded-xl px-5 py-3 flex items-center justify-between flex-wrap gap-3"
+        style={{ background: "var(--surface)", border: "1px solid var(--border)" }}
       >
-        <div className="flex items-center justify-between flex-wrap gap-2">
-          <SeverityBadge severity={result.output.severity} />
-          <div className="flex items-center gap-4">
-            <span className="text-xs font-mono px-2 py-1 rounded-md font-bold" style={{ background: "#10b98122", color: "#10b981", border: "1px solid #10b98133" }}>
-              {fmt$(result.cost_usd)} · {result.total_tokens.toLocaleString()} tokens
+        <div className="flex items-baseline gap-3 flex-wrap">
+          <span className="text-xs uppercase tracking-wider" style={{ color: "var(--text-muted)" }}>Model</span>
+          <span className="text-lg font-bold font-mono" style={{ color: "var(--accent)" }}>{state.model || "—"}</span>
+          <span className="text-xs" style={{ color: "var(--text-muted)" }}>via {PROVIDER_DISPLAY[state.provider] ?? state.provider}</span>
+          {state.mocked ? (
+            <span className="text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full" style={{ background: "#10b98122", color: "#10b981", border: "1px solid #10b98144" }}>
+              Simulated · proxymock
             </span>
-            <span className="text-xs font-mono" style={{ color: "var(--text-muted)" }}>{result.request_id}</span>
+          ) : state.request_id ? (
+            <span className="text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full" style={{ background: "#ef444422", color: "#ef4444", border: "1px solid #ef444444" }}>
+              Live · billed
+            </span>
+          ) : null}
+        </div>
+        {state.cost_usd > 0 && (
+          state.mocked ? (
+            <div className="flex flex-col items-end gap-0.5">
+              <span className="text-[10px] uppercase tracking-wider" style={{ color: "#10b981" }}>Saved by simulation</span>
+              <span className="text-sm font-mono font-bold px-3 py-1 rounded-md" style={{ background: "#10b98111", color: "#10b981", border: "1px solid #10b98133" }}>
+                {fmt$(state.cost_usd)} · {state.total_tokens.toLocaleString()} tok
+              </span>
+            </div>
+          ) : (
+            <div className="flex flex-col items-end gap-0.5">
+              <span className="text-[10px] uppercase tracking-wider" style={{ color: "#ef4444" }}>Live spend</span>
+              <span className="text-sm font-mono font-bold px-3 py-1 rounded-md" style={{ background: "#ef444411", color: "#ef4444", border: "1px solid #ef444433" }}>
+                {fmt$(state.cost_usd)} · {state.total_tokens.toLocaleString()} tok
+              </span>
+            </div>
+          )
+        )}
+      </div>
+
+      {/* Header: severity */}
+      <div className="rounded-xl p-5 space-y-4" style={{ background: severityBg, border: "1px solid var(--border)" }}>
+        <div className="flex items-center justify-between flex-wrap gap-2">
+          {state.severity ? (
+            <SeverityBadge severity={state.severity as "low" | "medium" | "high" | "critical"} />
+          ) : (
+            <span className="text-xs animate-pulse" style={{ color: "var(--text-muted)" }}>
+              {state.currentStep ? stepLabel[state.currentStep] : "Starting…"}
+            </span>
+          )}
+        </div>
+
+        {state.summary ? (
+          <div>
+            <p className="text-xs uppercase tracking-wider mb-1" style={{ color: "var(--text-muted)" }}>Summary</p>
+            <p className="text-sm leading-relaxed">{state.summary}</p>
           </div>
-        </div>
-        <div>
-          <p className="text-xs uppercase tracking-wider mb-1" style={{ color: "var(--text-muted)" }}>Summary</p>
-          <p className="text-sm leading-relaxed">{result.output.summary}</p>
-        </div>
-        {result.output.root_cause && (
+        ) : state.severity && (
+          <div>
+            <p className="text-xs uppercase tracking-wider mb-1" style={{ color: "var(--text-muted)" }}>Summary</p>
+            <div className="h-4 rounded animate-pulse" style={{ background: "var(--surface2)", width: "80%" }} />
+          </div>
+        )}
+
+        {state.root_cause && (
           <div>
             <p className="text-xs uppercase tracking-wider mb-1" style={{ color: "var(--text-muted)" }}>Root Cause</p>
-            <p className="text-sm leading-relaxed" style={{ color: "var(--text-muted)" }}>{result.output.root_cause}</p>
+            <p className="text-sm leading-relaxed" style={{ color: "var(--text-muted)" }}>{state.root_cause}</p>
           </div>
         )}
       </div>
 
-      <div className="rounded-xl p-5" style={{ background: "#10b98108", border: "1px solid #10b98133" }}>
-        <p className="text-xs uppercase tracking-wider mb-2" style={{ color: "#10b981" }}>Recommended Action</p>
-        <p className="text-sm leading-relaxed">{result.output.recommended_action}</p>
-      </div>
+      {/* Recommended action */}
+      {state.recommended_action ? (
+        <div className="rounded-xl p-5" style={{ background: "#10b98108", border: "1px solid #10b98133" }}>
+          <p className="text-xs uppercase tracking-wider mb-2" style={{ color: "#10b981" }}>Recommended Action</p>
+          <p className="text-sm leading-relaxed">{state.recommended_action}</p>
+        </div>
+      ) : state.summary && (
+        <div className="rounded-xl p-5 animate-pulse" style={{ background: "var(--surface)", border: "1px solid var(--border)" }}>
+          <p className="text-xs uppercase tracking-wider mb-2" style={{ color: "var(--text-muted)" }}>Drafting Response…</p>
+          <div className="h-4 rounded" style={{ background: "var(--surface2)", width: "60%" }} />
+        </div>
+      )}
 
-      {result.output.response_draft && (
+      {/* Response draft */}
+      {state.response_draft && (
         <div className="rounded-xl p-5 space-y-2" style={{ background: "var(--surface)", border: "1px solid var(--border)" }}>
           <div className="flex items-center justify-between">
             <p className="text-xs uppercase tracking-wider" style={{ color: "var(--text-muted)" }}>Draft Customer Response</p>
@@ -255,20 +315,21 @@ function ResultPanel({ result }: { result: RunResult }) {
               {expanded ? "collapse" : "expand"}
             </button>
           </div>
-          {expanded && (
-            <p className="text-sm leading-relaxed whitespace-pre-wrap">{result.output.response_draft}</p>
-          )}
-          {!expanded && (
-            <p className="text-sm leading-relaxed line-clamp-2" style={{ color: "var(--text-muted)" }}>{result.output.response_draft}</p>
+          {expanded ? (
+            <p className="text-sm leading-relaxed whitespace-pre-wrap">{state.response_draft}</p>
+          ) : (
+            <p className="text-sm leading-relaxed line-clamp-2" style={{ color: "var(--text-muted)" }}>{state.response_draft}</p>
           )}
         </div>
       )}
 
-      {/* LLM pipeline steps */}
-      {result.steps.length > 0 && (
+      {/* Pipeline steps */}
+      {(state.steps.length > 0 || state.status === "running") && (
         <div className="rounded-xl p-4 space-y-2" style={{ background: "var(--surface)", border: "1px solid var(--border)" }}>
-          <p className="text-xs uppercase tracking-wider mb-1" style={{ color: "var(--text-muted)" }}>Pipeline Steps ({result.steps.length} LLM calls)</p>
-          {result.steps.map((step) => (
+          <p className="text-xs uppercase tracking-wider mb-1" style={{ color: "var(--text-muted)" }}>
+            Pipeline Steps ({state.steps.length}/3 LLM calls)
+          </p>
+          {state.steps.map((step) => (
             <div key={step.name} className="flex items-center justify-between text-xs py-1.5 border-b last:border-0" style={{ borderColor: "var(--border)" }}>
               <span className="font-mono capitalize">{step.name}</span>
               <div className="flex gap-4" style={{ color: "var(--text-muted)" }}>
@@ -278,30 +339,47 @@ function ResultPanel({ result }: { result: RunResult }) {
               </div>
             </div>
           ))}
+          {state.status === "running" && state.currentStep && (
+            <div className="flex items-center justify-between text-xs py-1.5 animate-pulse">
+              <span className="font-mono capitalize" style={{ color: "var(--text-muted)" }}>{state.currentStep}</span>
+              <span style={{ color: "var(--text-muted)" }}>running…</span>
+            </div>
+          )}
         </div>
       )}
 
+      {/* Error */}
+      {state.error && (
+        <div className="rounded-xl p-4 text-sm" style={{ background: "#ef444411", border: "1px solid #ef444433", color: "#ef4444" }}>
+          {state.error}
+        </div>
+      )}
+
+      {/* Tool data */}
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-        {order?.result ? (
-          <ToolCard title="Order Details" data={order.result as Record<string, unknown>} />
-        ) : order?.error ? (
-          <div className="rounded-lg p-4" style={{ background: "#ef444411", border: "1px solid #ef444433" }}>
-            <p className="text-xs uppercase tracking-wider mb-1" style={{ color: "#ef4444" }}>Order Lookup Failed</p>
-            <p className="text-xs">{order.error}</p>
-          </div>
-        ) : null}
-        {policy?.result ? (
-          <ToolCard title="Return Policy" data={policy.result as Record<string, unknown>} />
-        ) : null}
+        {state.tool_calls.map((tc) =>
+          tc.result ? (
+            <ToolCard
+              key={tc.name}
+              title={tc.name === "lookup_order" ? "Order Details" : "Return Policy"}
+              data={tc.result as Record<string, unknown>}
+            />
+          ) : tc.error ? (
+            <div key={tc.name} className="rounded-lg p-4" style={{ background: "#ef444411", border: "1px solid #ef444433" }}>
+              <p className="text-xs uppercase tracking-wider mb-1" style={{ color: "#ef4444" }}>{tc.name} Failed</p>
+              <p className="text-xs">{tc.error}</p>
+            </div>
+          ) : null
+        )}
       </div>
 
-      <div className="flex items-center justify-between text-xs pt-1" style={{ color: "var(--text-muted)" }}>
-        <span>{result.provider} · {result.model} · {result.timing.total_ms}ms</span>
-        <div className="flex gap-4">
-          <a href={`/runs/${result.request_id}`} className="hover:opacity-80 underline">Full trace</a>
-          <a href={`/compare?a=${result.request_id}`} className="hover:opacity-80 underline">Compare</a>
+      {/* Footer */}
+      {state.request_id && (
+        <div className="flex items-center justify-end gap-4 text-xs pt-1" style={{ color: "var(--text-muted)" }}>
+          <a href={`/runs/${state.request_id}`} className="hover:opacity-80 underline">Full trace</a>
+          <a href={`/compare?a=${state.request_id}`} className="hover:opacity-80 underline">Compare</a>
         </div>
-      </div>
+      )}
     </div>
   );
 }
@@ -360,7 +438,6 @@ function SavingsEstimator({ items, runsPerDay }: { items: BatchItem[]; runsPerDa
         </span>
       </div>
 
-      {/* Hero: annual real vs simulation */}
       <div className="grid grid-cols-2 gap-3">
         <div className="rounded-xl p-4 text-center space-y-1" style={{ background: "#ef444411", border: "1px solid #ef444433" }}>
           <p className="text-xs uppercase tracking-wider" style={{ color: "#ef4444" }}>Annual LLM spend</p>
@@ -374,7 +451,6 @@ function SavingsEstimator({ items, runsPerDay }: { items: BatchItem[]; runsPerDa
         </div>
       </div>
 
-      {/* Per-provider annual breakdown */}
       <div className="space-y-2">
         <p className="text-xs uppercase tracking-wider" style={{ color: "var(--text-muted)" }}>Annual spend by provider</p>
         {Object.entries(byProvider)
@@ -430,12 +506,10 @@ function BatchResultsPanel({
   const pct = total > 0 ? Math.round((done / total) * 100) : 0;
   const totalCost = completed.reduce((sum, i) => sum + (i.result?.cost_usd ?? 0), 0);
   const totalTokens = completed.reduce((sum, i) => sum + (i.result?.total_tokens ?? 0), 0);
-
   const uniqueTicketIds = [...new Set(items.map((i) => i.ticket.id))];
 
   return (
     <div className="space-y-4">
-      {/* Progress header */}
       <div className="rounded-xl p-4 space-y-3" style={{ background: "var(--surface)", border: "1px solid var(--border)" }}>
         <div className="flex items-center justify-between text-sm flex-wrap gap-2">
           <span className="font-semibold">
@@ -460,10 +534,8 @@ function BatchResultsPanel({
         </div>
       </div>
 
-      {/* Savings estimator */}
       {done > 0 && <SavingsEstimator items={items} runsPerDay={runsPerDay} />}
 
-      {/* Results grid — one row per ticket, columns per provider */}
       {done > 0 && (
         <div className="space-y-2">
           {uniqueTicketIds.map((ticketId) => {
@@ -580,20 +652,24 @@ export default function HomePage() {
   const [model, setModel] = useState("");
   const [ticketIdx, setTicketIdx] = useState(0);
   const [transcript, setTranscript] = useState(SAMPLE_TICKETS[0].transcript);
-  const [result, setResult] = useState<RunResult | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const [runsPerDay, setRunsPerDay] = useState(10000);
+
+  // Per-ticket streaming state
+  const [ticketStates, setTicketStates] = useState<Record<string, TicketRunState>>({});
 
   // Batch state
   const [batchItems, setBatchItems] = useState<BatchItem[]>([]);
   const [batchDone, setBatchDone] = useState(0);
   const [batchTotal, setBatchTotal] = useState(0);
   const [batchRunning, setBatchRunning] = useState(false);
+  const [batchError, setBatchError] = useState<string | null>(null);
+  const [quickRunning, setQuickRunning] = useState(false);
 
-  const isBusy = loading || batchRunning;
-  const showBatch = batchTotal > 0;
   const currentTicket = SAMPLE_TICKETS[ticketIdx];
+  const currentTicketState = ticketStates[currentTicket.id];
+  const currentTicketRunning = currentTicketState?.status === "running";
+  const isBusy = currentTicketRunning || batchRunning || quickRunning;
+  const showBatch = batchTotal > 0;
 
   useEffect(() => {
     getProviders()
@@ -602,48 +678,263 @@ export default function HomePage() {
         setProvider(d.default_provider);
       })
       .catch(() => {});
+
+    // Seed per-ticket state from backend run history on load.
+    // Iterates oldest-to-newest so the most recent run per ticket wins.
+    listRuns(50)
+      .then(({ runs }) => {
+        const seed: Record<string, TicketRunState> = {};
+        for (const run of runs) {
+          if (!run.ticket_id) continue;
+          seed[run.ticket_id] = {
+            status: run.error ? "error" : "done",
+            provider: run.provider,
+            model: run.model,
+            severity: run.output.severity,
+            summary: run.output.summary,
+            root_cause: run.output.root_cause,
+            recommended_action: run.output.recommended_action,
+            response_draft: run.output.response_draft,
+            steps: run.steps,
+            tool_calls: run.tool_calls,
+            request_id: run.request_id,
+            total_tokens: run.total_tokens,
+            cost_usd: run.cost_usd,
+            mocked: run.mocked ?? false,
+            error: run.error,
+          };
+        }
+        if (Object.keys(seed).length > 0) setTicketStates(seed);
+      })
+      .catch(() => {});
   }, []);
 
   const selectedProvider = providers.find((p) => p.id === provider);
   const models = selectedProvider?.models ?? [];
 
-  function dispatchCostEvent(cost: number, tokens: number) {
-    window.dispatchEvent(new CustomEvent("run-complete", { detail: { cost, tokens } }));
+  function dispatchCostEvent(cost: number, tokens: number, mocked: boolean) {
+    window.dispatchEvent(new CustomEvent("run-complete", { detail: { cost, tokens, mocked } }));
   }
 
   async function handleRun() {
     setBatchTotal(0);
     setBatchItems([]);
-    setLoading(true);
-    setError(null);
+    setBatchError(null);
+
+    const ticketId = currentTicket.id;
+    const modelForRun = model || selectedProvider?.default_model || "";
+
+    setTicketStates((prev) => ({
+      ...prev,
+      [ticketId]: {
+        status: "running",
+        provider,
+        model: modelForRun,
+        steps: [],
+        tool_calls: [],
+        total_tokens: 0,
+        cost_usd: 0,
+        currentStep: "triage",
+      },
+    }));
+
     try {
-      const res = await runTask({
+      for await (const event of streamTask({
         provider,
         model: model || undefined,
-        input: {
-          ticket_id: currentTicket.id,
-          customer_tier: currentTicket.tier,
-          transcript,
-        },
-      });
-      setResult(res);
-      dispatchCostEvent(res.cost_usd, res.total_tokens);
+        input: { ticket_id: currentTicket.id, customer_tier: currentTicket.tier, transcript },
+      })) {
+        if (event.type === "tools") {
+          setTicketStates((prev) => ({
+            ...prev,
+            [ticketId]: { ...prev[ticketId], tool_calls: event.tool_calls },
+          }));
+        } else if (event.type === "step") {
+          const step: LLMStep = {
+            name: event.name,
+            prompt_tokens: event.prompt_tokens,
+            completion_tokens: event.completion_tokens,
+            cost_usd: event.cost_usd,
+            duration_ms: event.duration_ms,
+          };
+          setTicketStates((prev) => {
+            const curr = prev[ticketId];
+            const updates: Partial<TicketRunState> = {
+              steps: [...curr.steps, step],
+              currentStep: event.name === "triage" ? "analysis" : event.name === "analysis" ? "response" : undefined,
+            };
+            if (event.name === "triage") updates.severity = event.data.severity as string;
+            if (event.name === "analysis") {
+              updates.summary = event.data.summary as string;
+              updates.root_cause = event.data.root_cause as string;
+            }
+            if (event.name === "response") {
+              updates.recommended_action = event.data.recommended_action as string;
+              updates.response_draft = event.data.response_body as string;
+            }
+            return { ...prev, [ticketId]: { ...curr, ...updates } };
+          });
+        } else if (event.type === "complete") {
+          setTicketStates((prev) => ({
+            ...prev,
+            [ticketId]: {
+              ...prev[ticketId],
+              status: "done",
+              request_id: event.request_id,
+              total_tokens: event.total_tokens,
+              cost_usd: event.cost_usd,
+              mocked: event.mocked ?? false,
+              currentStep: undefined,
+            },
+          }));
+          dispatchCostEvent(event.cost_usd, event.total_tokens, event.mocked ?? false);
+        } else if (event.type === "error") {
+          setTicketStates((prev) => ({
+            ...prev,
+            [ticketId]: { ...prev[ticketId], status: "error", error: event.message, currentStep: undefined },
+          }));
+        }
+      }
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-    } finally {
-      setLoading(false);
+      setTicketStates((prev) => ({
+        ...prev,
+        [ticketId]: {
+          ...prev[ticketId],
+          status: "error",
+          error: e instanceof Error ? e.message : String(e),
+          currentStep: undefined,
+        },
+      }));
     }
+  }
+
+  async function handleTestAllModels() {
+    const configured = providers.filter((p) => p.configured);
+    if (configured.length === 0) {
+      setBatchError("No providers have API keys configured.");
+      return;
+    }
+
+    const combos: { provider: string; model: string; ticket: (typeof SAMPLE_TICKETS)[number] }[] = [];
+    let tIdx = 0;
+    for (const p of configured) {
+      for (const m of p.models) {
+        combos.push({
+          provider: p.id,
+          model: m,
+          ticket: SAMPLE_TICKETS[tIdx % SAMPLE_TICKETS.length],
+        });
+        tIdx++;
+      }
+    }
+
+    setBatchTotal(0);
+    setBatchItems([]);
+    setBatchError(null);
+    setQuickRunning(true);
+
+    // Seed state for every assigned ticket so buttons show the model immediately
+    setTicketStates((prev) => {
+      const next = { ...prev };
+      for (const combo of combos) {
+        next[combo.ticket.id] = {
+          status: "running",
+          provider: combo.provider,
+          model: combo.model,
+          steps: [],
+          tool_calls: [],
+          total_tokens: 0,
+          cost_usd: 0,
+          currentStep: "triage",
+        };
+      }
+      return next;
+    });
+
+    await Promise.all(
+      combos.map(async (combo) => {
+        const tid = combo.ticket.id;
+        try {
+          for await (const event of streamTask({
+            provider: combo.provider,
+            model: combo.model,
+            input: { ticket_id: combo.ticket.id, customer_tier: combo.ticket.tier, transcript: combo.ticket.transcript },
+          })) {
+            if (event.type === "tools") {
+              setTicketStates((prev) => ({ ...prev, [tid]: { ...prev[tid], tool_calls: event.tool_calls } }));
+            } else if (event.type === "step") {
+              const step: LLMStep = {
+                name: event.name,
+                prompt_tokens: event.prompt_tokens,
+                completion_tokens: event.completion_tokens,
+                cost_usd: event.cost_usd,
+                duration_ms: event.duration_ms,
+              };
+              setTicketStates((prev) => {
+                const curr = prev[tid];
+                if (!curr) return prev;
+                const updates: Partial<TicketRunState> = {
+                  steps: [...curr.steps, step],
+                  currentStep: event.name === "triage" ? "analysis" : event.name === "analysis" ? "response" : undefined,
+                };
+                if (event.name === "triage") updates.severity = event.data.severity as string;
+                if (event.name === "analysis") {
+                  updates.summary = event.data.summary as string;
+                  updates.root_cause = event.data.root_cause as string;
+                }
+                if (event.name === "response") {
+                  updates.recommended_action = event.data.recommended_action as string;
+                  updates.response_draft = event.data.response_body as string;
+                }
+                return { ...prev, [tid]: { ...curr, ...updates } };
+              });
+            } else if (event.type === "complete") {
+              setTicketStates((prev) => ({
+                ...prev,
+                [tid]: {
+                  ...prev[tid],
+                  status: "done",
+                  request_id: event.request_id,
+                  total_tokens: event.total_tokens,
+                  cost_usd: event.cost_usd,
+                  mocked: event.mocked ?? false,
+                  currentStep: undefined,
+                },
+              }));
+              dispatchCostEvent(event.cost_usd, event.total_tokens, event.mocked ?? false);
+            } else if (event.type === "error") {
+              setTicketStates((prev) => ({
+                ...prev,
+                [tid]: { ...prev[tid], status: "error", error: event.message, currentStep: undefined },
+              }));
+            }
+          }
+        } catch (e) {
+          setTicketStates((prev) => ({
+            ...prev,
+            [tid]: {
+              ...prev[tid],
+              status: "error",
+              error: e instanceof Error ? e.message : String(e),
+              currentStep: undefined,
+            },
+          }));
+        }
+      })
+    );
+
+    setQuickRunning(false);
   }
 
   async function handleAnalyzeAll() {
     const configured = providers.filter((p) => p.configured);
     if (configured.length === 0) {
-      setError("No providers have API keys configured.");
+      setBatchError("No providers have API keys configured.");
       return;
     }
 
-    setResult(null);
-    setError(null);
+    setTicketStates({});
+    setBatchError(null);
 
     const pairs: BatchItem[] = SAMPLE_TICKETS.flatMap((ticket) =>
       configured.map((p) => ({
@@ -676,7 +967,7 @@ export default function HomePage() {
           setBatchItems((prev) =>
             prev.map((it, i) => (i === idx ? { ...it, status: "done", result: res } : it))
           );
-          dispatchCostEvent(res.cost_usd, res.total_tokens);
+          dispatchCostEvent(res.cost_usd, res.total_tokens, res.mocked ?? false);
         } catch (e) {
           setBatchItems((prev) =>
             prev.map((it, i) =>
@@ -695,7 +986,7 @@ export default function HomePage() {
   }
 
   const configuredCount = providers.filter((p) => p.configured).length;
-  const totalCalls = SAMPLE_TICKETS.length * configuredCount * 3; // 3 LLM steps per ticket
+  const totalCalls = SAMPLE_TICKETS.length * configuredCount * 3;
 
   return (
     <div className="grid grid-cols-1 xl:grid-cols-[440px_1fr] gap-8">
@@ -709,10 +1000,7 @@ export default function HomePage() {
         </div>
 
         {/* Provider */}
-        <div
-          className="rounded-xl p-5 space-y-4"
-          style={{ background: "var(--surface)", border: "1px solid var(--border)" }}
-        >
+        <div className="rounded-xl p-5 space-y-4" style={{ background: "var(--surface)", border: "1px solid var(--border)" }}>
           <p className="text-sm font-semibold">Provider</p>
           <div className="grid grid-cols-2 gap-4">
             <div>
@@ -748,10 +1036,7 @@ export default function HomePage() {
         </div>
 
         {/* Ticket */}
-        <div
-          className="rounded-xl p-5 space-y-4"
-          style={{ background: "var(--surface)", border: "1px solid var(--border)" }}
-        >
+        <div className="rounded-xl p-5 space-y-4" style={{ background: "var(--surface)", border: "1px solid var(--border)" }}>
           <p className="text-sm font-semibold">Support Ticket</p>
 
           <div className="grid grid-cols-2 gap-4">
@@ -767,24 +1052,45 @@ export default function HomePage() {
 
           <div>
             <Label>Sample Ticket</Label>
-            <div className="flex gap-1 mb-2 flex-wrap">
-              {SAMPLE_TICKETS.map((t, i) => (
-                <button
-                  key={t.id}
-                  onClick={() => {
-                    setTicketIdx(i);
-                    setTranscript(t.transcript);
-                  }}
-                  className="text-xs px-2 py-0.5 rounded transition-colors"
-                  style={{
-                    background: ticketIdx === i ? "var(--accent)" : "var(--surface2)",
-                    color: ticketIdx === i ? "white" : "var(--text-muted)",
-                    border: "1px solid var(--border)",
-                  }}
-                >
-                  {t.id.replace("INC-", "")}
-                </button>
-              ))}
+            <div className="grid grid-cols-4 gap-1 mb-2">
+              {SAMPLE_TICKETS.map((t, i) => {
+                const ts = ticketStates[t.id];
+                const hasResult = ts && ts.status !== "running";
+                const isRunning = ts?.status === "running";
+                return (
+                  <button
+                    key={t.id}
+                    onClick={() => {
+                      setTicketIdx(i);
+                      setTranscript(t.transcript);
+                    }}
+                    title={ts?.model ?? ""}
+                    className="text-xs px-2 py-1 rounded transition-colors relative flex flex-col items-center leading-tight"
+                    style={{
+                      background: ticketIdx === i ? "var(--accent)" : "var(--surface2)",
+                      color: ticketIdx === i ? "white" : hasResult ? "var(--text)" : "var(--text-muted)",
+                      border: isRunning
+                        ? "1px solid var(--accent)"
+                        : hasResult
+                        ? `1px solid ${SEVERITY_COLORS[ts!.severity ?? "medium"] ?? "var(--border)"}44`
+                        : "1px solid var(--border)",
+                    }}
+                  >
+                    <span className="font-mono">
+                      {t.id.replace("INC-", "")}
+                      {isRunning && <span className="ml-1 animate-pulse">·</span>}
+                    </span>
+                    {ts?.model && (
+                      <span
+                        className="text-[9px] font-mono mt-0.5 truncate w-full text-center"
+                        style={{ color: ticketIdx === i ? "rgba(255,255,255,0.8)" : "var(--text-muted)" }}
+                      >
+                        {shortModel(ts.model)}
+                      </span>
+                    )}
+                  </button>
+                );
+              })}
             </div>
             <textarea
               value={transcript}
@@ -797,25 +1103,43 @@ export default function HomePage() {
         </div>
 
         {/* Action buttons */}
-        <div className="grid grid-cols-2 gap-3">
-          <button
-            onClick={handleRun}
-            disabled={isBusy}
-            className="py-3 rounded-xl font-semibold text-sm transition-all hover:opacity-90 disabled:opacity-50"
-            style={{ background: "var(--accent)", color: "white" }}
-          >
-            {loading ? "Analyzing…" : "Analyze Ticket"}
-          </button>
-          <button
-            onClick={handleAnalyzeAll}
-            disabled={isBusy}
-            className="py-3 rounded-xl font-semibold text-sm transition-all hover:opacity-90 disabled:opacity-50"
-            style={{ background: "var(--surface)", border: "1px solid var(--border)", color: "var(--text)" }}
-            title={`Run all ${SAMPLE_TICKETS.length} tickets × ${configuredCount} providers × 3 LLM calls = ${totalCalls} total`}
-          >
-            {batchRunning ? `${batchDone} / ${batchTotal}…` : "Analyze All"}
-          </button>
-        </div>
+        {(() => {
+          const allModelCount = providers.filter((p) => p.configured).reduce((n, p) => n + p.models.length, 0);
+          return (
+            <div className="space-y-2">
+              <button
+                onClick={handleTestAllModels}
+                disabled={isBusy}
+                className="w-full py-3 rounded-xl font-semibold text-sm transition-all hover:opacity-90 disabled:opacity-50"
+                style={{ background: "var(--accent)", color: "white" }}
+                title={`Runs one ticket through each configured model — ${allModelCount} models × 3 LLM calls = ${allModelCount * 3} calls`}
+              >
+                {quickRunning
+                  ? "Testing all models…"
+                  : `Test All Models · ${allModelCount} model${allModelCount === 1 ? "" : "s"}`}
+              </button>
+              <div className="grid grid-cols-2 gap-2">
+                <button
+                  onClick={handleRun}
+                  disabled={isBusy}
+                  className="py-2.5 rounded-xl font-medium text-sm transition-all hover:opacity-90 disabled:opacity-50"
+                  style={{ background: "var(--surface)", border: "1px solid var(--border)", color: "var(--text)" }}
+                >
+                  {currentTicketRunning ? "Analyzing…" : "Analyze Ticket"}
+                </button>
+                <button
+                  onClick={handleAnalyzeAll}
+                  disabled={isBusy}
+                  className="py-2.5 rounded-xl font-medium text-sm transition-all hover:opacity-90 disabled:opacity-50"
+                  style={{ background: "var(--surface)", border: "1px solid var(--border)", color: "var(--text)" }}
+                  title={`Run all ${SAMPLE_TICKETS.length} tickets × ${configuredCount} providers × 3 LLM calls = ${totalCalls} total`}
+                >
+                  {batchRunning ? `${batchDone} / ${batchTotal}…` : "Analyze All (heavy)"}
+                </button>
+              </div>
+            </div>
+          );
+        })()}
 
         {providers.length > 0 && (
           <div className="space-y-2">
@@ -823,7 +1147,6 @@ export default function HomePage() {
               Runs all {SAMPLE_TICKETS.length} tickets against each configured provider —{" "}
               <strong>{totalCalls} LLM calls total</strong>
             </p>
-            {/* Runs/day slider for savings estimator */}
             <div className="rounded-lg p-3 space-y-1.5" style={{ background: "var(--surface)", border: "1px solid var(--border)" }}>
               <div className="flex items-center justify-between text-xs">
                 <label style={{ color: "var(--text-muted)" }}>Support tickets / day</label>
@@ -851,15 +1174,12 @@ export default function HomePage() {
       {/* ── Right panel: result ── */}
       <div className="space-y-4">
         <h2 className="text-lg font-semibold">
-          {showBatch ? "Batch Results" : "Result"}
+          {showBatch ? "Batch Results" : `Result — ${currentTicket.id}`}
         </h2>
 
-        {error && (
-          <div
-            className="rounded-xl p-4 text-sm"
-            style={{ background: "#ef444411", border: "1px solid #ef444433", color: "#ef4444" }}
-          >
-            {error}
+        {batchError && (
+          <div className="rounded-xl p-4 text-sm" style={{ background: "#ef444411", border: "1px solid #ef444433", color: "#ef4444" }}>
+            {batchError}
           </div>
         )}
 
@@ -867,26 +1187,17 @@ export default function HomePage() {
           <BatchResultsPanel items={batchItems} done={batchDone} total={batchTotal} runsPerDay={runsPerDay} />
         ) : (
           <>
-            {loading && (
-              <div
-                className="rounded-xl p-8 text-center text-sm animate-pulse"
-                style={{ background: "var(--surface)", border: "1px solid var(--border)", color: "var(--text-muted)" }}
-              >
-                Running 3-step pipeline (triage → analysis → response)…
-              </div>
-            )}
-
-            {!loading && !result && !error && (
+            {!currentTicketState && (
               <div
                 className="rounded-xl p-8 text-center space-y-2"
                 style={{ background: "var(--surface)", border: "1px solid var(--border)", color: "var(--text-muted)" }}
               >
                 <p className="text-sm">Select a ticket and click <strong>Analyze Ticket</strong>.</p>
                 <p className="text-xs">Each ticket triggers <strong>3 sequential LLM calls</strong>: severity triage, root-cause analysis, and a draft customer response.</p>
+                <p className="text-xs">Results are saved per-ticket — click between tickets to compare.</p>
               </div>
             )}
-
-            {!loading && result && <ResultPanel result={result} />}
+            {currentTicketState && <StreamingResultPanel state={currentTicketState} />}
           </>
         )}
       </div>

--- a/llm-simulation-demo/frontend/src/app/runs/page.tsx
+++ b/llm-simulation-demo/frontend/src/app/runs/page.tsx
@@ -57,7 +57,7 @@ export default function RunsPage() {
             </div>
             <div className="flex items-center gap-4 flex-shrink-0">
               <span className="text-sm" style={{ color: "var(--text-muted)" }}>
-                {run.provider}
+                {run.provider} / {run.model}
               </span>
               <span className="text-xs" style={{ color: "var(--text-muted)" }}>
                 {run.timing.total_ms}ms

--- a/llm-simulation-demo/frontend/src/components/NavBar.tsx
+++ b/llm-simulation-demo/frontend/src/components/NavBar.tsx
@@ -9,14 +9,17 @@ function fmt$(n: number): string {
 }
 
 export function NavBar() {
-  const [sessionCost, setSessionCost] = useState(0);
-  const [sessionTokens, setSessionTokens] = useState(0);
+  const [liveCost, setLiveCost] = useState(0);
+  const [savedCost, setSavedCost] = useState(0);
 
   useEffect(() => {
     function onRunComplete(e: Event) {
-      const { cost, tokens } = (e as CustomEvent<{ cost: number; tokens: number }>).detail;
-      setSessionCost((prev) => prev + (cost ?? 0));
-      setSessionTokens((prev) => prev + (tokens ?? 0));
+      const { cost, mocked } = (e as CustomEvent<{ cost: number; tokens: number; mocked?: boolean }>).detail;
+      if (mocked) {
+        setSavedCost((prev) => prev + (cost ?? 0));
+      } else {
+        setLiveCost((prev) => prev + (cost ?? 0));
+      }
     }
     window.addEventListener("run-complete", onRunComplete);
     return () => window.removeEventListener("run-complete", onRunComplete);
@@ -33,36 +36,41 @@ export function NavBar() {
             <a href="/" className="hover:text-white transition-colors">Analyze</a>
             <a href="/runs" className="hover:text-white transition-colors">History</a>
             <a href="/compare" className="hover:text-white transition-colors">Compare</a>
+            <a href="/costs" className="hover:text-white transition-colors">Costs</a>
           </div>
         </div>
 
-        {/* Live session cost meter */}
-        <div className="flex items-center gap-2">
-          {sessionCost > 0 ? (
-            <>
-              <div
-                className="flex items-center gap-2 text-xs px-3 py-1.5 rounded-lg"
-                style={{ background: "#ef444411", border: "1px solid #ef444433" }}
-              >
-                <span style={{ color: "var(--text-muted)" }}>Session cost</span>
-                <span className="font-mono font-bold" style={{ color: "#ef4444" }}>{fmt$(sessionCost)}</span>
-                <span style={{ color: "var(--text-muted)" }}>·</span>
-                <span className="font-mono" style={{ color: "var(--text-muted)" }}>{sessionTokens.toLocaleString()} tok</span>
-              </div>
-              <div
-                className="flex items-center gap-2 text-xs px-3 py-1.5 rounded-lg"
-                style={{ background: "#10b98111", border: "1px solid #10b98133" }}
-              >
-                <span style={{ color: "var(--text-muted)" }}>with simulation</span>
-                <span className="font-mono font-bold" style={{ color: "#10b981" }}>$0.00</span>
-              </div>
-            </>
-          ) : (
-            <span className="text-xs" style={{ color: "var(--text-muted)" }}>
-              Session cost: <span className="font-mono">$0.00</span>
+        {/* Compact session badges — live spend (red) vs simulated savings (green) */}
+        <a
+          href="/costs"
+          className="flex items-center gap-2 transition-opacity hover:opacity-80"
+          title="Click for full cost breakdown"
+        >
+          <span
+            className="flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-lg"
+            style={{
+              background: liveCost > 0 ? "#ef444411" : "var(--surface2)",
+              border: `1px solid ${liveCost > 0 ? "#ef444433" : "var(--border)"}`,
+            }}
+          >
+            <span style={{ color: "var(--text-muted)" }}>Live</span>
+            <span className="font-mono font-bold" style={{ color: liveCost > 0 ? "#ef4444" : "var(--text-muted)" }}>
+              {fmt$(liveCost)}
             </span>
-          )}
-        </div>
+          </span>
+          <span
+            className="flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-lg"
+            style={{
+              background: savedCost > 0 ? "#10b98111" : "var(--surface2)",
+              border: `1px solid ${savedCost > 0 ? "#10b98133" : "var(--border)"}`,
+            }}
+          >
+            <span style={{ color: "var(--text-muted)" }}>Saved</span>
+            <span className="font-mono font-bold" style={{ color: savedCost > 0 ? "#10b981" : "var(--text-muted)" }}>
+              {fmt$(savedCost)}
+            </span>
+          </span>
+        </a>
       </div>
     </nav>
   );

--- a/llm-simulation-demo/frontend/src/lib/api.ts
+++ b/llm-simulation-demo/frontend/src/lib/api.ts
@@ -1,9 +1,5 @@
-import type { ProviderInfo, RunRequest, RunResult } from "./types";
+import type { ProviderInfo, RunRequest, RunResult, StreamEvent } from "./types";
 
-// Browser: use "" so requests go to /api/... on the same origin (proxied by the
-// Next.js route handler at src/app/api/[...path]/route.ts).
-// Server-side: call the backend directly using BACKEND_URL (a plain env var read
-// at runtime, not baked at build time like NEXT_PUBLIC_* vars).
 const API_BASE =
   typeof window !== "undefined"
     ? ""
@@ -26,6 +22,40 @@ export async function runTask(req: RunRequest): Promise<RunResult> {
     method: "POST",
     body: JSON.stringify(req),
   });
+}
+
+export async function* streamTask(req: RunRequest): AsyncGenerator<StreamEvent> {
+  const res = await fetch(`${API_BASE}/api/run/stream`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(req),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => res.statusText);
+    throw new Error(`API /api/run/stream → ${res.status}: ${text}`);
+  }
+
+  const reader = res.body!.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const blocks = buffer.split("\n\n");
+    buffer = blocks.pop() ?? "";
+    for (const block of blocks) {
+      const dataLine = block.split("\n").find((l) => l.startsWith("data: "));
+      if (!dataLine) continue;
+      try {
+        yield JSON.parse(dataLine.slice(6)) as StreamEvent;
+      } catch {
+        // skip malformed event
+      }
+    }
+  }
 }
 
 export async function getProviders(): Promise<{ providers: ProviderInfo[]; default_provider: string }> {

--- a/llm-simulation-demo/frontend/src/lib/types.ts
+++ b/llm-simulation-demo/frontend/src/lib/types.ts
@@ -41,6 +41,7 @@ export interface TimingInfo {
 
 export interface RunResult {
   request_id: string;
+  ticket_id?: string;
   provider: string;
   model: string;
   output: OutputEnvelope;
@@ -49,6 +50,7 @@ export interface RunResult {
   timing: TimingInfo;
   total_tokens: number;
   cost_usd: number;
+  mocked?: boolean;
   error?: string;
 }
 
@@ -57,4 +59,31 @@ export interface ProviderInfo {
   models: string[];
   default_model: string;
   configured: boolean;
+}
+
+// SSE event types from /api/run/stream
+export type StreamEvent =
+  | { type: "tools"; tool_calls: ToolCallRecord[] }
+  | { type: "step"; name: string; data: Record<string, unknown>; prompt_tokens: number; completion_tokens: number; cost_usd: number; duration_ms: number; mocked?: boolean }
+  | { type: "complete"; request_id: string; total_tokens: number; cost_usd: number; mocked?: boolean }
+  | { type: "error"; message: string };
+
+// Per-ticket streaming state accumulated on the frontend
+export interface TicketRunState {
+  status: "running" | "done" | "error";
+  provider: string;
+  model: string;
+  severity?: string;
+  summary?: string;
+  root_cause?: string;
+  recommended_action?: string;
+  response_draft?: string;
+  steps: LLMStep[];
+  tool_calls: ToolCallRecord[];
+  request_id?: string;
+  total_tokens: number;
+  cost_usd: number;
+  mocked?: boolean;
+  error?: string;
+  currentStep?: "triage" | "analysis" | "response";
 }

--- a/node-websocket/node_modules/.package-lock.json
+++ b/node-websocket/node_modules/.package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "packages": {
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/node-websocket/node_modules/ws/lib/sender.js
+++ b/node-websocket/node_modules/ws/lib/sender.js
@@ -4,6 +4,9 @@
 
 const { Duplex } = require('stream');
 const { randomFillSync } = require('crypto');
+const {
+  types: { isUint8Array }
+} = require('util');
 
 const PerMessageDeflate = require('./permessage-deflate');
 const { EMPTY_BUFFER, kWebSocket, NOOP } = require('./constants');
@@ -200,8 +203,10 @@ class Sender {
 
       if (typeof data === 'string') {
         buf.write(data, 2);
-      } else {
+      } else if (isUint8Array(data)) {
         buf.set(data, 2);
+      } else {
+        throw new TypeError('Second argument must be a string or a Uint8Array');
       }
     }
 

--- a/node-websocket/node_modules/ws/package.json
+++ b/node-websocket/node_modules/ws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws",
-  "version": "8.20.0",
+  "version": "8.20.1",
   "description": "Simple to use, blazing fast and thoroughly tested websocket client and server for Node.js",
   "keywords": [
     "HyBi",

--- a/node-websocket/package-lock.json
+++ b/node-websocket/package-lock.json
@@ -13,9 +13,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
## Summary

- Default each provider to its most expensive model (`claude-opus-4-7`, `gpt-5.5`, `gemini-pro-latest`, `grok-4.20-0309-non-reasoning`) so the demo racks up meaningful spend in a few clicks.
- Add a **Test All Models** button on the homepage that fires one ticket per configured `(provider, model)` combo through the streaming endpoint. Each ticket button shows its assigned model; the result panel surfaces `Model · via Provider` as a prominent header.
- **Mock-mode awareness**: detect proxymock replays via the `X-Speedscale-*` response headers it stamps on every replay, plumb a `mocked` flag through `StepEvent → AdapterResult → RunResult`, and flip the UI framing:
  - Result panel header gets a `Live · billed` (red) or `Simulated · proxymock` (green) chip; the cost badge says "Live spend" vs "Saved by simulation" accordingly.
  - NavBar splits the inline meter into two badges: `Live $X` (red) and `Saved $Y` (green). The CustomEvent now carries `mocked`.
  - New **/costs** tab (sourced from `/api/runs` so it survives refresh) splits totals into Live vs Saved, adds a Mode column to the per-model table, and uses the live baseline for the cost-at-scale projection (with a fallback note when there are no live runs yet).
- Workaround for [S-10993](https://linear.app/speedscale/issue/S-10993): pin OpenAI/xAI client `Accept-Encoding: gzip` so proxymock can faithfully replay responses. (Bug is that the responder serves decoded bodies but keeps the original `Content-Encoding: br` header; clients with brotli installed then fail to decompress.)

## Test plan

- [ ] Restart the backend so the new mocked-detection plumbing loads.
- [ ] **Live mode**: with proxymock OFF, click **Test All Models**. Every ticket result shows the **Live · billed** red chip and the NavBar `Live` badge climbs.
- [ ] **Mock mode**: record fresh proxymock traffic against the backend (the workaround means OpenAI traffic is now gzip-only), then replay with `proxymock mock`. Click **Test All Models** again. Tickets now show the **Simulated · proxymock** green chip, NavBar `Saved` climbs while `Live` stays put.
- [ ] **Costs tab**: with a mix of live + mocked runs, totals show in both columns, the by-model table has Live/Simulated rows, scale projection uses the live baseline.
- [ ] **Refresh**: hard-refresh the browser. Per-ticket results, including `mocked`, hydrate from `/api/runs` — backend is the source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)