### PR TITLE
feat(grafana): Speedscale Traffic dashboard for BYOC RRPair exploration

### DIFF
--- a/reference-architectures/grafana/README.md
+++ b/reference-architectures/grafana/README.md
@@ -49,7 +49,14 @@ kubectl -n observability get pods
 - Visualization: Grafana Explore and dashboards.
 
 ```bash
-kubectl -n observability port-forward svc/grafana 3000:3000
+kubectl -n observability port-forward svc/grafana 38030:3000
 ```
 
-Open `http://localhost:3000` (admin/admin), then in Explore query `{source="speedscale"}`.
+Open `http://localhost:38030` (admin/admin), then in Explore query `{source="speedscale"}`.
+
+Two dashboards are auto-provisioned under the **Speedscale BYOC** folder:
+
+- **Speedscale BYOC** — infra view (forwarder metrics, queue depths, raw log stream)
+- **Speedscale Traffic** — RRPair traffic explorer (filter by service / method / status / endpoint regex; one-line-per-request format; expand any row for the full JSON with req/res bodies)
+
+The host port `38030` is chosen to dodge the common 3000-3999 dev-server range. If you change it, change it consistently across `port-forward` and any docs that reference the URL.

--- a/reference-architectures/grafana/manifests/grafana-loki.yaml
+++ b/reference-architectures/grafana/manifests/grafana-loki.yaml
@@ -250,7 +250,7 @@ data:
           "datasource": { "type": "loki", "uid": "loki" },
           "targets": [
             {
-              "expr": "sum(count_over_time({service=~\"$service\", cluster=~\"$cluster\"} | json | keep body_command, body_status, body_location | body_command=~\"$method\" | body_status=~\"$status\" | body_location=~\"$endpoint\" [$__range]))",
+              "expr": "sum(count_over_time({service=~\"$service\", cluster=~\"$cluster\"} | json | keep cluster, service, body_command, body_status, body_location | body_command=~\"$method\" | body_status=~\"$status\" | body_location=~\"$endpoint\" [$__range]))",
               "refId": "A",
               "instant": true
             }
@@ -264,7 +264,7 @@ data:
           "datasource": { "type": "loki", "uid": "loki" },
           "targets": [
             {
-              "expr": "100 * sum(count_over_time({service=~\"$service\", cluster=~\"$cluster\"} | json | keep body_command, body_status, body_location | body_command=~\"$method\" | body_status=~\"$status\" | body_location=~\"$endpoint\" | body_status=~\"[45]..\" [$__range])) / sum(count_over_time({service=~\"$service\", cluster=~\"$cluster\"} | json | keep body_command, body_status, body_location | body_command=~\"$method\" | body_status=~\"$status\" | body_location=~\"$endpoint\" [$__range]))",
+              "expr": "100 * sum(count_over_time({service=~\"$service\", cluster=~\"$cluster\"} | json | keep cluster, service, body_command, body_status, body_location | body_command=~\"$method\" | body_status=~\"$status\" | body_location=~\"$endpoint\" | body_status=~\"[45]..\" [$__range])) / sum(count_over_time({service=~\"$service\", cluster=~\"$cluster\"} | json | keep cluster, service, body_command, body_status, body_location | body_command=~\"$method\" | body_status=~\"$status\" | body_location=~\"$endpoint\" [$__range]))",
               "refId": "A",
               "instant": true
             }
@@ -285,7 +285,7 @@ data:
           "datasource": { "type": "loki", "uid": "loki" },
           "targets": [
             {
-              "expr": "quantile_over_time(0.95, {service=~\"$service\", cluster=~\"$cluster\"} | json | keep body_command, body_status, body_location, body_duration | body_command=~\"$method\" | body_status=~\"$status\" | body_location=~\"$endpoint\" | unwrap body_duration [$__range])",
+              "expr": "quantile_over_time(0.95, {service=~\"$service\", cluster=~\"$cluster\"} | json | keep cluster, service, body_command, body_status, body_location, body_duration | body_command=~\"$method\" | body_status=~\"$status\" | body_location=~\"$endpoint\" | unwrap body_duration [$__range])",
               "refId": "A",
               "instant": true
             }
@@ -300,7 +300,7 @@ data:
           "datasource": { "type": "loki", "uid": "loki" },
           "targets": [
             {
-              "expr": "count(count by (body_location) (count_over_time({service=~\"$service\", cluster=~\"$cluster\"} | json | keep body_command, body_status, body_location | body_command=~\"$method\" | body_status=~\"$status\" | body_location=~\"$endpoint\" [$__range])))",
+              "expr": "count(count by (body_location) (count_over_time({service=~\"$service\", cluster=~\"$cluster\"} | json | keep cluster, service, body_command, body_status, body_location | body_command=~\"$method\" | body_status=~\"$status\" | body_location=~\"$endpoint\" [$__range])))",
               "refId": "A",
               "instant": true
             }
@@ -314,8 +314,8 @@ data:
           "datasource": { "type": "loki", "uid": "loki" },
           "targets": [
             {
-              "expr": "sum by (body_location) (rate({service=~\"$service\", cluster=~\"$cluster\"} | json | keep body_command, body_status, body_location | body_command=~\"$method\" | body_status=~\"$status\" | body_location=~\"$endpoint\" [1m]))",
-              "legendFormat": "{{body_location}}",
+              "expr": "sum by (cluster, service, body_location) (rate({service=~\"$service\", cluster=~\"$cluster\"} | json | keep cluster, service, body_command, body_status, body_location | body_command=~\"$method\" | body_status=~\"$status\" | body_location=~\"$endpoint\" [1m]))",
+              "legendFormat": "{{cluster}}/{{service}} {{body_location}}",
               "refId": "A"
             }
           ],
@@ -328,17 +328,17 @@ data:
           "datasource": { "type": "loki", "uid": "loki" },
           "targets": [
             {
-              "expr": "quantile_over_time(0.50, {service=~\"$service\", cluster=~\"$cluster\"} | json | keep body_command, body_status, body_location, body_duration | body_command=~\"$method\" | body_status=~\"$status\" | body_location=~\"$endpoint\" | unwrap body_duration [1m])",
+              "expr": "quantile_over_time(0.50, {service=~\"$service\", cluster=~\"$cluster\"} | json | keep cluster, service, body_command, body_status, body_location, body_duration | body_command=~\"$method\" | body_status=~\"$status\" | body_location=~\"$endpoint\" | unwrap body_duration [1m])",
               "legendFormat": "p50",
               "refId": "A"
             },
             {
-              "expr": "quantile_over_time(0.95, {service=~\"$service\", cluster=~\"$cluster\"} | json | keep body_command, body_status, body_location, body_duration | body_command=~\"$method\" | body_status=~\"$status\" | body_location=~\"$endpoint\" | unwrap body_duration [1m])",
+              "expr": "quantile_over_time(0.95, {service=~\"$service\", cluster=~\"$cluster\"} | json | keep cluster, service, body_command, body_status, body_location, body_duration | body_command=~\"$method\" | body_status=~\"$status\" | body_location=~\"$endpoint\" | unwrap body_duration [1m])",
               "legendFormat": "p95",
               "refId": "B"
             },
             {
-              "expr": "quantile_over_time(0.99, {service=~\"$service\", cluster=~\"$cluster\"} | json | keep body_command, body_status, body_location, body_duration | body_command=~\"$method\" | body_status=~\"$status\" | body_location=~\"$endpoint\" | unwrap body_duration [1m])",
+              "expr": "quantile_over_time(0.99, {service=~\"$service\", cluster=~\"$cluster\"} | json | keep cluster, service, body_command, body_status, body_location, body_duration | body_command=~\"$method\" | body_status=~\"$status\" | body_location=~\"$endpoint\" | unwrap body_duration [1m])",
               "legendFormat": "p99",
               "refId": "C"
             }
@@ -352,7 +352,7 @@ data:
           "datasource": { "type": "loki", "uid": "loki" },
           "targets": [
             {
-              "expr": "sum by (body_status) (count_over_time({service=~\"$service\", cluster=~\"$cluster\"} | json | keep body_command, body_status, body_location | body_command=~\"$method\" | body_status=~\"$status\" | body_location=~\"$endpoint\" [$__range]))",
+              "expr": "sum by (body_status) (count_over_time({service=~\"$service\", cluster=~\"$cluster\"} | json | keep cluster, service, body_command, body_status, body_location | body_command=~\"$method\" | body_status=~\"$status\" | body_location=~\"$endpoint\" [$__range]))",
               "legendFormat": "{{body_status}}",
               "refId": "A",
               "instant": true
@@ -367,7 +367,7 @@ data:
           "datasource": { "type": "loki", "uid": "loki" },
           "targets": [
             {
-              "expr": "sum by (body_location) (count_over_time({service=~\"$service\", cluster=~\"$cluster\"} | json | keep body_command, body_status, body_location | body_command=~\"$method\" | body_status=~\"$status\" | body_location=~\"$endpoint\" [$__range]))",
+              "expr": "sum by (cluster, service, body_location) (count_over_time({service=~\"$service\", cluster=~\"$cluster\"} | json | keep cluster, service, body_command, body_status, body_location | body_command=~\"$method\" | body_status=~\"$status\" | body_location=~\"$endpoint\" [$__range]))",
               "refId": "A",
               "instant": true,
               "format": "table"
@@ -378,7 +378,8 @@ data:
               "id": "organize",
               "options": {
                 "excludeByName": { "Time": true },
-                "renameByName": { "body_location": "endpoint", "Value": "requests" }
+                "indexByName": { "cluster": 0, "service": 1, "body_location": 2, "Value": 3 },
+                "renameByName": { "cluster": "cluster", "service": "app", "body_location": "endpoint", "Value": "requests" }
               }
             },
             { "id": "sortBy", "options": { "fields": {}, "sort": [{ "field": "requests", "desc": true }] } }
@@ -387,12 +388,12 @@ data:
         {
           "type": "logs",
           "title": "Recent traffic (filtered)",
-          "description": "One line per request. Method, status, latency (ms), endpoint, then a [dlp] hint when DLP modified the record. Click a row to expand the full RRPair JSON including request/response bodies (base64).",
+          "description": "One line per request: cluster/app, method, status, latency (ms), endpoint, then a [dlp] hint when DLP modified the record. Click a row to expand the full RRPair JSON including request/response bodies (base64).",
           "gridPos": { "h": 14, "w": 24, "x": 0, "y": 21 },
           "datasource": { "type": "loki", "uid": "loki" },
           "targets": [
             {
-              "expr": "{service=~\"$service\", cluster=~\"$cluster\"} | json | keep body_command, body_status, body_duration, body_location, body_dlpModified | body_command=~\"$method\" | body_status=~\"$status\" | body_location=~\"$endpoint\" | line_format \"{{.body_command}} {{.body_status}} {{ printf \\\"%4s\\\" .body_duration }}ms  {{.body_location}}  {{ if eq .body_dlpModified \\\"true\\\" }}[dlp]{{end}}\"",
+              "expr": "{service=~\"$service\", cluster=~\"$cluster\"} | json | keep cluster, service, body_command, body_status, body_duration, body_location, body_dlpModified | body_command=~\"$method\" | body_status=~\"$status\" | body_location=~\"$endpoint\" | line_format \"{{.cluster}}/{{.service}}  {{.body_command}} {{.body_status}} {{ printf \\\"%4s\\\" .body_duration }}ms  {{.body_location}}  {{ if eq .body_dlpModified \\\"true\\\" }}[dlp]{{end}}\"",
               "refId": "A"
             }
           ],
@@ -424,7 +425,7 @@ data:
           },
           {
             "name": "service",
-            "label": "Service",
+            "label": "App / Service",
             "type": "query",
             "datasource": { "type": "loki", "uid": "loki" },
             "query": { "label": "service", "stream": "{cluster=~\"$cluster\"}", "type": 1 },

--- a/reference-architectures/grafana/manifests/grafana-loki.yaml
+++ b/reference-architectures/grafana/manifests/grafana-loki.yaml
@@ -232,6 +232,244 @@ data:
       "version": 2,
       "weekStart": ""
     }
+  speedscale-traffic.json: |
+    {
+      "annotations": { "list": [] },
+      "description": "Speedscale RRPair traffic viewer for BYOC + Loki. Inspired by the Speedscale Cloud traffic explorer — filter by service, method, status class, and endpoint regex; drill into recent requests without scrolling through raw JSON blobs.",
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "id": null,
+      "links": [],
+      "liveNow": false,
+      "panels": [
+        {
+          "type": "stat",
+          "title": "Requests",
+          "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+          "datasource": { "type": "loki", "uid": "loki" },
+          "targets": [
+            {
+              "expr": "sum(count_over_time({service=~\"$service\", cluster=~\"$cluster\"} | json | keep body_command, body_status, body_location | body_command=~\"$method\" | body_status=~\"$status\" | body_location=~\"$endpoint\" [$__range]))",
+              "refId": "A",
+              "instant": true
+            }
+          ],
+          "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "area" }
+        },
+        {
+          "type": "stat",
+          "title": "Error rate (4xx/5xx)",
+          "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+          "datasource": { "type": "loki", "uid": "loki" },
+          "targets": [
+            {
+              "expr": "100 * sum(count_over_time({service=~\"$service\", cluster=~\"$cluster\"} | json | keep body_command, body_status, body_location | body_command=~\"$method\" | body_status=~\"$status\" | body_location=~\"$endpoint\" | body_status=~\"[45]..\" [$__range])) / sum(count_over_time({service=~\"$service\", cluster=~\"$cluster\"} | json | keep body_command, body_status, body_location | body_command=~\"$method\" | body_status=~\"$status\" | body_location=~\"$endpoint\" [$__range]))",
+              "refId": "A",
+              "instant": true
+            }
+          ],
+          "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "area" },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percent",
+              "noValue": "0",
+              "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 1 }, { "color": "red", "value": 5 }] }
+            }
+          }
+        },
+        {
+          "type": "stat",
+          "title": "p95 latency",
+          "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+          "datasource": { "type": "loki", "uid": "loki" },
+          "targets": [
+            {
+              "expr": "quantile_over_time(0.95, {service=~\"$service\", cluster=~\"$cluster\"} | json | keep body_command, body_status, body_location, body_duration | body_command=~\"$method\" | body_status=~\"$status\" | body_location=~\"$endpoint\" | unwrap body_duration [$__range])",
+              "refId": "A",
+              "instant": true
+            }
+          ],
+          "options": { "reduceOptions": { "calcs": ["max"] }, "colorMode": "value", "graphMode": "area" },
+          "fieldConfig": { "defaults": { "unit": "ms" } }
+        },
+        {
+          "type": "stat",
+          "title": "Distinct endpoints",
+          "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+          "datasource": { "type": "loki", "uid": "loki" },
+          "targets": [
+            {
+              "expr": "count(count by (body_location) (count_over_time({service=~\"$service\", cluster=~\"$cluster\"} | json | keep body_command, body_status, body_location | body_command=~\"$method\" | body_status=~\"$status\" | body_location=~\"$endpoint\" [$__range])))",
+              "refId": "A",
+              "instant": true
+            }
+          ],
+          "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "none" }
+        },
+        {
+          "type": "timeseries",
+          "title": "Request rate by endpoint",
+          "gridPos": { "h": 9, "w": 12, "x": 0, "y": 4 },
+          "datasource": { "type": "loki", "uid": "loki" },
+          "targets": [
+            {
+              "expr": "sum by (body_location) (rate({service=~\"$service\", cluster=~\"$cluster\"} | json | keep body_command, body_status, body_location | body_command=~\"$method\" | body_status=~\"$status\" | body_location=~\"$endpoint\" [1m]))",
+              "legendFormat": "{{body_location}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "stacking": { "mode": "normal" }, "fillOpacity": 30, "lineWidth": 1 }, "unit": "reqps" } }
+        },
+        {
+          "type": "timeseries",
+          "title": "Latency percentiles",
+          "gridPos": { "h": 9, "w": 12, "x": 12, "y": 4 },
+          "datasource": { "type": "loki", "uid": "loki" },
+          "targets": [
+            {
+              "expr": "quantile_over_time(0.50, {service=~\"$service\", cluster=~\"$cluster\"} | json | keep body_command, body_status, body_location, body_duration | body_command=~\"$method\" | body_status=~\"$status\" | body_location=~\"$endpoint\" | unwrap body_duration [1m])",
+              "legendFormat": "p50",
+              "refId": "A"
+            },
+            {
+              "expr": "quantile_over_time(0.95, {service=~\"$service\", cluster=~\"$cluster\"} | json | keep body_command, body_status, body_location, body_duration | body_command=~\"$method\" | body_status=~\"$status\" | body_location=~\"$endpoint\" | unwrap body_duration [1m])",
+              "legendFormat": "p95",
+              "refId": "B"
+            },
+            {
+              "expr": "quantile_over_time(0.99, {service=~\"$service\", cluster=~\"$cluster\"} | json | keep body_command, body_status, body_location, body_duration | body_command=~\"$method\" | body_status=~\"$status\" | body_location=~\"$endpoint\" | unwrap body_duration [1m])",
+              "legendFormat": "p99",
+              "refId": "C"
+            }
+          ],
+          "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "fillOpacity": 10, "lineWidth": 2 }, "unit": "ms" } }
+        },
+        {
+          "type": "barchart",
+          "title": "Status code distribution",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 13 },
+          "datasource": { "type": "loki", "uid": "loki" },
+          "targets": [
+            {
+              "expr": "sum by (body_status) (count_over_time({service=~\"$service\", cluster=~\"$cluster\"} | json | keep body_command, body_status, body_location | body_command=~\"$method\" | body_status=~\"$status\" | body_location=~\"$endpoint\" [$__range]))",
+              "legendFormat": "{{body_status}}",
+              "refId": "A",
+              "instant": true
+            }
+          ],
+          "options": { "orientation": "horizontal", "xTickLabelRotation": 0, "showValue": "auto" }
+        },
+        {
+          "type": "table",
+          "title": "Top endpoints by request count",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 13 },
+          "datasource": { "type": "loki", "uid": "loki" },
+          "targets": [
+            {
+              "expr": "sum by (body_location) (count_over_time({service=~\"$service\", cluster=~\"$cluster\"} | json | keep body_command, body_status, body_location | body_command=~\"$method\" | body_status=~\"$status\" | body_location=~\"$endpoint\" [$__range]))",
+              "refId": "A",
+              "instant": true,
+              "format": "table"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": { "Time": true },
+                "renameByName": { "body_location": "endpoint", "Value": "requests" }
+              }
+            },
+            { "id": "sortBy", "options": { "fields": {}, "sort": [{ "field": "requests", "desc": true }] } }
+          ]
+        },
+        {
+          "type": "logs",
+          "title": "Recent traffic (filtered)",
+          "description": "One line per request. Method, status, latency (ms), endpoint, then a [dlp] hint when DLP modified the record. Click a row to expand the full RRPair JSON including request/response bodies (base64).",
+          "gridPos": { "h": 14, "w": 24, "x": 0, "y": 21 },
+          "datasource": { "type": "loki", "uid": "loki" },
+          "targets": [
+            {
+              "expr": "{service=~\"$service\", cluster=~\"$cluster\"} | json | keep body_command, body_status, body_duration, body_location, body_dlpModified | body_command=~\"$method\" | body_status=~\"$status\" | body_location=~\"$endpoint\" | line_format \"{{.body_command}} {{.body_status}} {{ printf \\\"%4s\\\" .body_duration }}ms  {{.body_location}}  {{ if eq .body_dlpModified \\\"true\\\" }}[dlp]{{end}}\"",
+              "refId": "A"
+            }
+          ],
+          "options": {
+            "showTime": true,
+            "showLabels": false,
+            "wrapLogMessage": false,
+            "enableLogDetails": true,
+            "sortOrder": "Descending",
+            "dedupStrategy": "none"
+          }
+        }
+      ],
+      "refresh": "10s",
+      "schemaVersion": 39,
+      "tags": ["speedscale", "byoc", "traffic"],
+      "templating": {
+        "list": [
+          {
+            "name": "cluster",
+            "label": "Cluster",
+            "type": "query",
+            "datasource": { "type": "loki", "uid": "loki" },
+            "query": { "label": "cluster", "stream": "", "type": 1 },
+            "refresh": 2,
+            "includeAll": true,
+            "multi": true,
+            "current": { "selected": false, "text": "All", "value": ".+" }
+          },
+          {
+            "name": "service",
+            "label": "Service",
+            "type": "query",
+            "datasource": { "type": "loki", "uid": "loki" },
+            "query": { "label": "service", "stream": "{cluster=~\"$cluster\"}", "type": 1 },
+            "refresh": 2,
+            "includeAll": true,
+            "multi": true,
+            "current": { "selected": false, "text": "All", "value": ".+" }
+          },
+          {
+            "name": "method",
+            "label": "Method (regex)",
+            "type": "textbox",
+            "current": { "value": ".+", "text": ".+" },
+            "options": [{ "value": ".+", "text": ".+", "selected": true }]
+          },
+          {
+            "name": "status",
+            "label": "Status (regex)",
+            "type": "custom",
+            "query": ".+,2..,4..,5..",
+            "current": { "value": ".+", "text": ".+" },
+            "options": [
+              { "value": ".+", "text": "any", "selected": true },
+              { "value": "2..", "text": "2xx" },
+              { "value": "4..", "text": "4xx" },
+              { "value": "5..", "text": "5xx" }
+            ]
+          },
+          {
+            "name": "endpoint",
+            "label": "Endpoint (regex)",
+            "type": "textbox",
+            "current": { "value": ".+", "text": ".+" },
+            "options": [{ "value": ".+", "text": ".+", "selected": true }]
+          }
+        ]
+      },
+      "time": { "from": "now-15m", "to": "now" },
+      "timepicker": { "refresh_intervals": ["5s", "10s", "30s", "1m"] },
+      "timezone": "",
+      "title": "Speedscale Traffic",
+      "uid": "speedscale-traffic",
+      "version": 2,
+      "weekStart": ""
+    }
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim


### PR DESCRIPTION
## Summary

Adds a second Grafana dashboard alongside the existing **Speedscale BYOC** (which is infra-focused). This one is inspired by the Speedscale Cloud traffic viewer — meant for digging into the actual RRPair stream coming out of `byoc_otel`, not the forwarder's plumbing.

### Variables
- **cluster** / **service** — auto-populated from Loki labels
- **method** — regex over the HTTP method
- **status** — `2xx` / `4xx` / `5xx` / `any` quick-pick
- **endpoint** — regex over the URL path

### Panels
| Row | Panels |
|---|---|
| KPIs | Requests · Error rate % · p95 latency · Distinct endpoints |
| Time series | Request rate by endpoint (stacked) · Latency percentiles (p50/p95/p99) |
| Distribution | Status code distribution (bar) · Top endpoints by request count (sortable table) |
| Traffic table | **Recent traffic** logs panel with `line_format` rendering `METHOD STATUS DURATIONms PATH [dlp]` — click any row to expand the full RRPair JSON including request/response bodies (base64) and the `tokenList` of DLP-redacted bearer tokens |

### Implementation notes

Every metric query uses `| json | keep <fields>` to limit what Loki extracts to labels — a stock RRPair has ~60 nested fields and a naïve `| json` query hits Loki's 500-series cap on the first quantile aggregation. The dashboard keeps only the handful of fields each panel actually filters/groups on.

### Verified on miniken

| Panel | Result |
|---|---|
| All 11 panel queries | ✅ return data |
| Error rate math | ✅ 2 forced 403s out of 824 reqs → 0.24% (matches manual calc) |
| Status distribution | ✅ shows `200: 822, 403: 2` |
| `line_format` table | ✅ renders as `GET 200 1ms /spacex/ship [dlp]` etc. |
| Dashboard provisioning | ✅ file provider auto-loads from `grafana-dashboards` ConfigMap |

## Test plan

- [ ] `kubectl apply -f reference-architectures/grafana/manifests/grafana-loki.yaml` updates the ConfigMap cleanly
- [ ] After grafana pod restart, both **Speedscale BYOC** and **Speedscale Traffic** appear under the "Speedscale BYOC" folder
- [ ] Open Speedscale Traffic with default vars — KPI row populates, time series render, recent traffic table shows one-line-per-request format
- [ ] Set `status=4xx` — error rate jumps, table filters down
- [ ] Set `endpoint=/spacex/.+` — request rate panel filters to spacex paths
- [ ] Click a row in Recent traffic → expanded view shows full RRPair JSON with `body.http.req.bodyBase64`, `body.http.res.bodyBase64`, and `body.tokenList` for redacted JWTs

🤖 Generated with [Claude Code](https://claude.com/claude-code)