### PR TITLE
feat(grafana/scripts): loki-gather.py — BYOC traffic → proxymock-replayable directory

### DIFF
--- a/reference-architectures/grafana/README.md
+++ b/reference-architectures/grafana/README.md
@@ -4,57 +4,32 @@ This reference architecture captures real traffic from your apps, ships it throu
 
 ## Architecture
 
-The full loop, from production capture to replay against an app under test:
-
 ```mermaid
 flowchart LR
-  subgraph cluster["BYOC Kubernetes cluster"]
-    direction TB
-    apps["Your apps<br/>(real traffic)"]
-    cap["Speedscale nettap<br/>eBPF capture"]
-    fwd["Speedscale Forwarder<br/>DLP + filter rules<br/>byoc_otel exporter"]
-    otel["OTel Collector<br/>:4317 gRPC&nbsp;·&nbsp;:4318 HTTP"]
-    loki[("Loki<br/>RRPair logs<br/>indexed by<br/>cluster · service · namespace")]
-    grafana["Grafana<br/><i>Speedscale Traffic</i><br/>dashboard"]
-
-    apps -.-> cap
-    cap --> fwd
-    fwd ==>|OTLP| otel
-    otel --> loki
-    loki --> grafana
-  end
-
-  subgraph local["Local dev / CI"]
-    direction TB
-    gather["<b>loki-gather.py</b><br/>filter by service,<br/>endpoint, status, time"]
-    snapshot[("Snapshot directory<br/>per-host .json<br/>RRPair files")]
-    pm["proxymock<br/>mock / replay"]
-    app["App under test"]
-
-    gather --> snapshot
-    snapshot --> pm
-    pm <-->|"proxy :4140"| app
-  end
-
-  loki ==>|"LogQL query<br/>(any subset)"| gather
-  grafana -.->|"explore,<br/>pick a filter"| gather
-
-  classDef cluster fill:#e3f2fd,stroke:#1976d2,stroke-width:2px
-  classDef local fill:#fff3e0,stroke:#f57c00,stroke-width:2px
-  classDef storage fill:#f3e5f5,stroke:#7b1fa2
-
-  class loki,snapshot storage
+    apps([Your apps]) --> fwd[Speedscale Forwarder]
+    fwd -- OTLP --> col[OTel Collector]
+    col --> loki[(Loki)]
+    loki --> grafana[Grafana]
+    loki --> gather[loki-gather.py]
+    gather --> snap[(Snapshot dir)]
+    snap --> pm[proxymock]
+    pm <--> test([App under test])
 ```
 
-**Two halves.** The left half is the *capture* loop — Speedscale's operator + forwarder ship RRPairs into Loki, where you can index and visualize them like any other observability data. The right half is the *replay* loop — `loki-gather.py` pulls any subset out of Loki into a directory `proxymock` can read, so the same real traffic you captured drives your test environment.
+**Capture half** (apps → forwarder → OTel → Loki, with Grafana on top). The Forwarder's `byoc_otel` exporter ships RRPairs as OTLP logs into your own Loki — no Speedscale Cloud round-trip.
 
-The two halves run independently. You don't need a Speedscale Cloud round-trip; everything stays in your own infra.
+**Replay half** (Loki → gather → snapshot → proxymock → app). `loki-gather.py` queries any subset back out and writes a proxymock-readable directory. Same real traffic you captured drives your tests.
 
-## Install (Minikube)
+## Prerequisites
+
+- A Kubernetes cluster (any flavor — `kind`, `minikube`, EKS, GKE, AKS, k3s)
+- `kubectl` configured against it
+- `helm` v3
+- A Speedscale API key (`SPEEDSCALE_API_KEY`) and your app URL
+
+## Install
 
 ```bash
-minikube start
-
 kubectl apply -f manifests/namespaces.yaml
 
 helm repo add speedscale https://speedscale.github.io/operator-helm/

--- a/reference-architectures/grafana/README.md
+++ b/reference-architectures/grafana/README.md
@@ -4,21 +4,25 @@ This reference architecture captures real traffic from your apps, ships it throu
 
 ## Architecture
 
+**Capture.** The Forwarder's `byoc_otel` exporter ships RRPairs as OTLP logs into your own Loki — no Speedscale Cloud round-trip. Grafana sits on top for indexing, dashboards, and ad-hoc queries.
+
 ```mermaid
-flowchart TB
+flowchart LR
     apps([Your apps]) --> fwd[Speedscale Forwarder]
-    fwd -- OTLP --> col[OTel Collector]
+    fwd --> col[OTel Collector]
     col --> loki[(Loki)]
     loki --> grafana[Grafana]
-    loki --> gather[loki-gather.py]
+```
+
+**Replay.** `loki-gather.py` queries any subset of Loki back out and writes a `proxymock`-readable directory. Same real traffic you captured drives your tests.
+
+```mermaid
+flowchart LR
+    loki[(Loki)] --> gather[loki-gather.py]
     gather --> snap[(Snapshot dir)]
     snap --> pm[proxymock]
     pm <--> test([App under test])
 ```
-
-**Capture half** (apps → forwarder → OTel → Loki, with Grafana on top). The Forwarder's `byoc_otel` exporter ships RRPairs as OTLP logs into your own Loki — no Speedscale Cloud round-trip.
-
-**Replay half** (Loki → gather → snapshot → proxymock → app). `loki-gather.py` queries any subset back out and writes a proxymock-readable directory. Same real traffic you captured drives your tests.
 
 ## Prerequisites
 

--- a/reference-architectures/grafana/README.md
+++ b/reference-architectures/grafana/README.md
@@ -1,22 +1,54 @@
 # Speedscale BYOC: Grafana + Loki
 
-This reference architecture exports Speedscale RRPair logs through OTEL into Loki, then visualizes in Grafana.
+This reference architecture captures real traffic from your apps, ships it through the Speedscale Forwarder to your own Loki, and lets you slice it through Grafana — then pull any subset back out as a `proxymock`-replayable directory for tests.
 
 ## Architecture
 
+The full loop, from production capture to replay against an app under test:
+
 ```mermaid
 flowchart LR
-  subgraph K8s[BYOC Kubernetes Cluster]
-    Apps[Payment Apps]
-    Cap[eBPF nettap or sidecar capture]
-    Fwd[Speedscale Forwarder\nDLP + filter rules]
-    OTel[OTEL Collector]
-    Loki[Loki]
-    Grafana[Grafana]
+  subgraph cluster["BYOC Kubernetes cluster"]
+    direction TB
+    apps["Your apps<br/>(real traffic)"]
+    cap["Speedscale nettap<br/>eBPF capture"]
+    fwd["Speedscale Forwarder<br/>DLP + filter rules<br/>byoc_otel exporter"]
+    otel["OTel Collector<br/>:4317 gRPC&nbsp;·&nbsp;:4318 HTTP"]
+    loki[("Loki<br/>RRPair logs<br/>indexed by<br/>cluster · service · namespace")]
+    grafana["Grafana<br/><i>Speedscale Traffic</i><br/>dashboard"]
+
+    apps -.-> cap
+    cap --> fwd
+    fwd ==>|OTLP| otel
+    otel --> loki
+    loki --> grafana
   end
 
-  Apps --> Cap --> Fwd --> OTel --> Loki --> Grafana
+  subgraph local["Local dev / CI"]
+    direction TB
+    gather["<b>loki-gather.py</b><br/>filter by service,<br/>endpoint, status, time"]
+    snapshot[("Snapshot directory<br/>per-host .json<br/>RRPair files")]
+    pm["proxymock<br/>mock / replay"]
+    app["App under test"]
+
+    gather --> snapshot
+    snapshot --> pm
+    pm <-->|"proxy :4140"| app
+  end
+
+  loki ==>|"LogQL query<br/>(any subset)"| gather
+  grafana -.->|"explore,<br/>pick a filter"| gather
+
+  classDef cluster fill:#e3f2fd,stroke:#1976d2,stroke-width:2px
+  classDef local fill:#fff3e0,stroke:#f57c00,stroke-width:2px
+  classDef storage fill:#f3e5f5,stroke:#7b1fa2
+
+  class loki,snapshot storage
 ```
+
+**Two halves.** The left half is the *capture* loop — Speedscale's operator + forwarder ship RRPairs into Loki, where you can index and visualize them like any other observability data. The right half is the *replay* loop — `loki-gather.py` pulls any subset out of Loki into a directory `proxymock` can read, so the same real traffic you captured drives your test environment.
+
+The two halves run independently. You don't need a Speedscale Cloud round-trip; everything stays in your own infra.
 
 ## Install (Minikube)
 
@@ -60,3 +92,23 @@ Two dashboards are auto-provisioned under the **Speedscale BYOC** folder:
 - **Speedscale Traffic** — RRPair traffic explorer (filter by service / method / status / endpoint regex; one-line-per-request format; expand any row for the full JSON with req/res bodies)
 
 The host port `38030` is chosen to dodge the common 3000-3999 dev-server range. If you change it, change it consistently across `port-forward` and any docs that reference the URL.
+
+## Replay (gather a subset of traffic into proxymock)
+
+Once Loki has some real traffic, you can pull any slice of it out as a directory `proxymock` reads:
+
+```bash
+kubectl -n observability port-forward svc/loki 3101:3100 &
+
+python3 scripts/loki-gather.py \
+  --loki-url http://localhost:3101 \
+  --service  java-server \
+  --status   2.. \
+  --endpoint '^/spacex/.+' \
+  --start    -15m \
+  --out-dir  /tmp/spacex-snapshot
+
+proxymock mock --in /tmp/spacex-snapshot
+```
+
+The gathered directory is the same shape `speedctl proxymock cloud pull snapshot` produces after expanding a cloud snapshot — so anything in the proxymock ecosystem that reads a recording works without changes. See `scripts/README.md` for filter flags, workflow notes (`mock` vs `replay`, IN vs OUT direction), and known gotchas.

--- a/reference-architectures/grafana/README.md
+++ b/reference-architectures/grafana/README.md
@@ -5,7 +5,7 @@ This reference architecture captures real traffic from your apps, ships it throu
 ## Architecture
 
 ```mermaid
-flowchart LR
+flowchart TB
     apps([Your apps]) --> fwd[Speedscale Forwarder]
     fwd -- OTLP --> col[OTel Collector]
     col --> loki[(Loki)]

--- a/reference-architectures/grafana/scripts/README.md
+++ b/reference-architectures/grafana/scripts/README.md
@@ -77,9 +77,22 @@ Then route your app's outbound traffic through `localhost:4140` (the default pro
 - **Loki cardinality cap (500 series).** The script's LogQL always pipes through `| keep <small-field-list>` after `| json`. A naïve `| json` extracts ~60 nested fields per record and blows past the cap on any aggregate query.
 - **Port conflicts.** If your gathered set includes a Postgres or MySQL recording, `proxymock mock` will try to bind ports 5432 / 3306. Conflicts with anything local listening there. Filter to HTTP only (`--logql '{...} | json | body_l7protocol="http"'`) if needed.
 
+### Want markdown files instead of JSON?
+
+This script writes `.json` only — proxymock owns format conversion. Replay the snapshot through `proxymock` and ask it to write markdown:
+
+```bash
+# Gather as .json (this script)
+python3 loki-gather.py --out-dir /tmp/snap …
+
+# Re-emit as .md via proxymock
+proxymock mock --in /tmp/snap --out /tmp/snap-md --out-format markdown
+```
+
+We deliberately don't reimplement the markdown encoder in Python — the canonical implementation lives in `lib/rrfile/markdown/codec.go`, and keeping two encoders in sync as the format evolves is a maintenance trap.
+
 ### What's deliberately not here (yet)
 
-- Markdown output (`--md`). `.json` is what proxymock expands cloud snapshots into, so the format is proven and easier. Markdown is more readable but requires base64-decoding bodies, recomposing the request line, joining header arrays — not worth doing twice if we end up promoting this to a real tool.
 - Pagination / auto-windowing for large time ranges. Today, big windows can exhaust Loki's per-query limit; either narrow the window or use multiple invocations.
 - Auth (`--bearer-token`, `--basic-auth`). The BYOC reference Loki has no auth. Add when needed.
 

--- a/reference-architectures/grafana/scripts/README.md
+++ b/reference-architectures/grafana/scripts/README.md
@@ -1,0 +1,86 @@
+# BYOC companion scripts
+
+Small, single-file tools that pair with the BYOC + Grafana reference architecture. They live next to the manifests so anyone reading the demo can fork them without setting up a separate repo.
+
+Pattern intent: as we add gather/replay scripts for other reference architectures (`elasticsearch/`, `fluent-bit/`), they move under each scenario's `scripts/` directory. Once a handful exist they get promoted to their own repo with proper packaging — for now this is the playground.
+
+## `loki-gather.py`
+
+Pull a subset of RRPair traffic from Loki and write a `proxymock`-replayable directory. The "gather" half of Speedscale Cloud's Create-Snapshot flow, sourced from Loki instead of the cloud's S3-backed snapshot store. Analysis is proxymock's job once the directory exists.
+
+### Requirements
+
+- Python 3.9+ (stdlib only — no `pip install`)
+- A reachable Loki HTTP endpoint (typically `kubectl port-forward svc/loki 3101:3100` against the BYOC reference architecture)
+- `proxymock` if you want to replay the result
+
+### Usage
+
+```bash
+python3 loki-gather.py \
+  --loki-url http://localhost:3101 \
+  --start    -15m \
+  --service  java-server \
+  --status   2.. \
+  --endpoint '^/spacex/.+' \
+  --out-dir  /tmp/spacex-snapshot
+```
+
+This pulls the last 15 minutes of successful (`2xx`) inbound traffic to `java-server` matching `/spacex/.+`, and writes one `.json` file per RRPair under `/tmp/spacex-snapshot/snapshot-<uuid>/<host>/`.
+
+### Filter flags (translated to LogQL)
+
+| Flag | What it filters |
+|---|---|
+| `--cluster X` | Loki stream label |
+| `--service X` | Loki stream label |
+| `--namespace X` | Loki stream label |
+| `--method GET` | HTTP method (regex) |
+| `--status 2..` | HTTP status (regex) |
+| `--endpoint '^/api/.+'` | URL path (regex) |
+| `--direction IN\|OUT` | Capture direction |
+
+For full LogQL control, pass `--logql '<your query>'` and the other filter flags are ignored.
+
+### Output
+
+```
+<out-dir>/
+├── .metadata/
+│   └── snapshot.json              # synthesized: id, source=loki, time window, logql
+└── snapshot-<uuid>/
+    ├── java-server/
+    │   ├── <rrpair-uuid>.json     # one file per RRPair (proto JSON form)
+    │   └── ...
+    └── <other-host>/
+        └── ...
+```
+
+Same shape `speedctl proxymock cloud pull snapshot` produces after expanding a cloud snapshot — so anything downstream that reads either source works without modification.
+
+### Replay with proxymock
+
+After gathering, point proxymock at the directory:
+
+```bash
+proxymock mock --in /tmp/spacex-snapshot
+```
+
+Then route your app's outbound traffic through `localhost:4140` (the default proxymock proxy port) to get recorded responses.
+
+**Workflow note**: `proxymock mock` answers your app's *outbound* calls — so the relevant records are `direction=OUT` ones (e.g. an app's call to `api.fiscaldata.treasury.gov`). If you want to *replay* inbound traffic against a service (e.g. exercise `java-server` with its recorded request stream), filter to `--direction IN` and use `proxymock replay` instead.
+
+### Known gotchas
+
+- **`body.cluster` workaround.** The forwarder ships `body.cluster: "undefined"` for every record today ([S-11091](https://linear.app/speedscale/issue/S-11091)). The script overwrites it with the Loki stream label `cluster` so downstream tools see the right cluster name. Same for `body.namespace`.
+- **Signature `instance` numbers.** The cloud snapshot analyzer normally adds an `instance: N` field to each recorded signature so proxymock can deterministically dedupe replays of the same call. We skip the analyzer (by design), so the script assigns instance numbers itself by sorting records by Loki ingest order.
+- **Loki cardinality cap (500 series).** The script's LogQL always pipes through `| keep <small-field-list>` after `| json`. A naïve `| json` extracts ~60 nested fields per record and blows past the cap on any aggregate query.
+- **Port conflicts.** If your gathered set includes a Postgres or MySQL recording, `proxymock mock` will try to bind ports 5432 / 3306. Conflicts with anything local listening there. Filter to HTTP only (`--logql '{...} | json | body_l7protocol="http"'`) if needed.
+
+### What's deliberately not here (yet)
+
+- Markdown output (`--md`). `.json` is what proxymock expands cloud snapshots into, so the format is proven and easier. Markdown is more readable but requires base64-decoding bodies, recomposing the request line, joining header arrays — not worth doing twice if we end up promoting this to a real tool.
+- Pagination / auto-windowing for large time ranges. Today, big windows can exhaust Loki's per-query limit; either narrow the window or use multiple invocations.
+- Auth (`--bearer-token`, `--basic-auth`). The BYOC reference Loki has no auth. Add when needed.
+
+See [S-11101](https://linear.app/speedscale/issue/S-11101) for the design history and the "phase 2 → speedctl integration" path.

--- a/reference-architectures/grafana/scripts/loki-gather.py
+++ b/reference-architectures/grafana/scripts/loki-gather.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+"""loki-gather.py — pull a subset of BYOC RRPair traffic from Loki and write a
+proxymock-replayable directory.
+
+This is the "gather" half of the Speedscale Cloud Create-Snapshot flow, sourced
+from Loki instead of Speedscale's S3 snapshot store. Once this script writes
+the directory, `proxymock mock --in <dir>` (or `proxymock replay`) serves the
+recorded responses — analysis is proxymock's job, not this script's.
+
+Pattern intent: companion scripts live next to the reference architecture they
+enable. Today this script lives in the BYOC + Grafana reference arch under
+demos/. Once we accumulate a handful (loki-gather, elasticsearch-gather,
+fluent-bit-gather…) they get promoted to their own repo with proper packaging.
+For now: stdlib only, no `pip install`, easy to fork.
+
+Usage:
+
+    python3 loki-gather.py \\
+      --loki-url http://localhost:38030 \\
+      --service  java-server \\
+      --status   2.. \\
+      --endpoint '^/spacex/.+' \\
+      --start    -15m \\
+      --out-dir  /tmp/spacex-snapshot
+
+    proxymock mock --in /tmp/spacex-snapshot --listen :8080
+
+Power-user mode bypasses the flag translation:
+
+    python3 loki-gather.py \\
+      --loki-url http://localhost:38030 \\
+      --logql    '{service="java-server"} | json | body_status=~"2.."' \\
+      --start    -15m \\
+      --out-dir  /tmp/x
+
+Reference: see Linear S-11101 for the design + Loki→RRPair conversion table.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid as uuid_mod
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+# ─── time parsing ───────────────────────────────────────────────────────────
+
+
+def parse_time(s: str, *, now: datetime | None = None) -> datetime:
+    """Accept 'now', a relative offset like '-15m' / '-1h' / '-2d', or RFC3339.
+
+    Everything else raises argparse-friendly ValueError.
+    """
+    now = now or datetime.now(timezone.utc)
+    s = s.strip()
+    if s in ("now", ""):
+        return now
+    m = re.fullmatch(r"-(\d+)([smhd])", s)
+    if m:
+        n, unit = int(m.group(1)), m.group(2)
+        delta = {"s": timedelta(seconds=n), "m": timedelta(minutes=n), "h": timedelta(hours=n), "d": timedelta(days=n)}[unit]
+        return now - delta
+    # try parsing as RFC3339; accept "Z" or +00:00 forms
+    try:
+        return datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except ValueError:
+        raise ValueError(f"can't parse time {s!r} — use 'now', '-15m'/'-2h'/'-1d', or RFC3339")
+
+
+# ─── LogQL construction ─────────────────────────────────────────────────────
+
+
+# Fields we extract from the JSON body so LogQL filter pipeline stages can act
+# on them. Keeping this list minimal (vs the ~60 fields in a full RRPair) is
+# what keeps Loki under its 500-series cardinality cap on metric/aggregate
+# queries — same lesson the Grafana Speedscale Traffic dashboard learned.
+KEEP_FIELDS = [
+    "cluster", "service", "namespace",
+    "body_command", "body_status", "body_location", "body_direction",
+    "body_uuid", "body_ts", "body_duration",
+]
+
+
+def build_logql(args: argparse.Namespace) -> str:
+    """Translate the human-friendly CLI flags into a single LogQL query string.
+
+    Stream-label selectors (cluster/service/namespace) go inside the {…} matcher
+    so Loki uses its index — much cheaper than post-filter. Body fields require
+    `| json` parsing and then post-filter stages.
+    """
+    if args.logql:
+        return args.logql
+
+    stream: list[str] = []
+    for label, val in (("cluster", args.cluster), ("service", args.service), ("namespace", args.namespace)):
+        if val:
+            stream.append(f'{label}="{val}"')
+    # Loki requires at least one stream matcher; default to "any service" so
+    # the user can pass only body-level filters if they want.
+    if not stream:
+        stream.append('service=~".+"')
+
+    parser_stage = "| json | keep " + ", ".join(KEEP_FIELDS)
+    pipeline = [parser_stage]
+
+    if args.method:
+        pipeline.append(f'| body_command=~"{args.method}"')
+    if args.status:
+        pipeline.append(f'| body_status=~"{args.status}"')
+    if args.endpoint:
+        pipeline.append(f'| body_location=~"{args.endpoint}"')
+    if args.direction:
+        pipeline.append(f'| body_direction="{args.direction}"')
+
+    return "{" + ", ".join(stream) + "} " + " ".join(pipeline)
+
+
+# ─── Loki query ─────────────────────────────────────────────────────────────
+
+
+def query_loki(loki_url: str, logql: str, start: datetime, end: datetime, limit: int) -> list[tuple[dict, dict]]:
+    """Single query_range call against Loki.
+
+    Returns a list of (stream_labels, body) pairs — one per matching log line.
+    `body` is the RRPair JSON object originally emitted by the forwarder; the
+    stream labels are the OTEL resource attrs that came in as Loki indexed
+    labels (cluster, service, namespace, exporter).
+
+    Pagination/auto-windowing for big time ranges is a phase-2 improvement;
+    today we trust the caller to keep windows reasonable (default 15m).
+    """
+    base = loki_url.rstrip("/")
+    api = f"{base}/loki/api/v1/query_range"
+    qs = urllib.parse.urlencode({
+        "query":     logql,
+        "start":     f"{int(start.timestamp() * 1_000_000_000)}",
+        "end":       f"{int(end.timestamp()   * 1_000_000_000)}",
+        "limit":     str(limit),
+        "direction": "backward",  # newest first; matches Speedscale cloud snapshot ordering
+    })
+    url = f"{api}?{qs}"
+
+    try:
+        with urllib.request.urlopen(url, timeout=30) as r:
+            payload = json.load(r)
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"Loki returned HTTP {e.code}: {body[:300]}") from None
+    except urllib.error.URLError as e:
+        raise RuntimeError(f"can't reach Loki at {api}: {e.reason}") from None
+
+    if payload.get("status") != "success":
+        raise RuntimeError(f"Loki returned non-success: {payload!r}")
+
+    out: list[tuple[dict, dict]] = []
+    for stream in payload.get("data", {}).get("result", []):
+        labels = stream.get("stream", {})
+        for _ts_ns, line in stream.get("values", []):
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                # not our format — skip silently. The forwarder emits one
+                # `body`-shaped object per line; anything else is noise (e.g.
+                # health checks, debug exporter logs) we don't want.
+                continue
+            body = rec.get("body")
+            if not isinstance(body, dict):
+                continue
+            out.append((labels, body))
+    return out
+
+
+# ─── signature instance numbering ───────────────────────────────────────────
+
+
+# When multiple recorded RRPairs share the same signature (same host+method+url+
+# queryparams), proxymock dedupes them via an `instance: N` field added to the
+# signature map. Cloud snapshots have this because the analyzer assigns it
+# during snapshot processing — we skip the analyzer entirely (by design), so we
+# have to assign instance numbers ourselves before writing.
+#
+# Without this, proxymock loads our files but the responder can't tell two
+# /spacex/launches recordings apart and ends up rejecting requests with
+# "your request did not match any mock signature" even when a match exists.
+
+
+def _signature_key(sig: dict) -> tuple:
+    """Stable comparison key for a signature map. Ignores any existing
+    `instance` field so we re-number from scratch.
+    """
+    return tuple(sorted((k, v) for k, v in sig.items() if k != "instance"))
+
+
+def assign_instances(records: list[tuple[dict, dict]]) -> None:
+    """Mutate each record's `body.signature` to include an `instance` value.
+
+    Records are processed in arrival order (which is `direction=backward` from
+    Loki, i.e. newest first). For each unique signature, the first record gets
+    instance="0", the second instance="1", and so on — matching the dedup
+    contract proxymock's responder expects.
+    """
+    counts: dict[tuple, int] = {}
+    for _stream, body in records:
+        sig = body.get("signature")
+        if not isinstance(sig, dict):
+            continue
+        key = _signature_key(sig)
+        n = counts.get(key, 0)
+        # Signature values are base64-encoded bytes when this object is the
+        # proto JSON form; encode "N" the same way for consistency.
+        sig["instance"] = base64.b64encode(str(n).encode()).decode()
+        counts[key] = n + 1
+
+
+# ─── RRPair fixups + file writing ───────────────────────────────────────────
+
+
+# Some forwarder fields ship as the literal string "undefined" when not wired
+# (see Linear S-11091 for the cluster case). The OTEL resource attribute is
+# correct on the stream label, so we copy it down into the body before writing.
+# Once S-11091 lands this becomes a no-op; the script stays correct either way.
+_UNDEFINED_FIELDS = ("cluster", "namespace")
+
+
+def fix_record(body: dict, stream: dict) -> dict:
+    """Apply minimal fixups so the emitted RRPair matches what proxymock expects.
+
+    Mutates `body` in place AND returns it (convenience).
+    """
+    for field in _UNDEFINED_FIELDS:
+        if body.get(field) in ("undefined", "", None):
+            label_val = stream.get(field)
+            if label_val:
+                body[field] = label_val
+    return body
+
+
+def base64_uuid_to_str(b64: str) -> str:
+    """RRPair UUIDs ship as 16-byte values base64-encoded. proxymock writes them
+    as RFC-4122 hyphenated strings in filenames; we do the same so the snapshot
+    directory is byte-identical to a `proxymock record` output.
+    """
+    try:
+        raw = base64.b64decode(b64, validate=False)
+        if len(raw) == 16:
+            return str(uuid_mod.UUID(bytes=raw))
+    except (ValueError, TypeError):
+        pass
+    # Fall back to a deterministic-but-arbitrary uuid so a bad input doesn't
+    # silently collapse multiple records onto the same filename.
+    return str(uuid_mod.uuid4())
+
+
+def write_rrpair(body: dict, snapshot_dir: Path) -> Path:
+    """Write a single RRPair JSON file under <snapshot_dir>/<host>/<uuid>.json.
+
+    The on-disk shape matches what `speedctl proxymock cloud pull snapshot`
+    expands to, so `proxymock mock --in <out-dir>` reads it as-is via
+    lib/rrfile/reader.go's DecodeRRFile path.
+    """
+    host = (body.get("http") or {}).get("req", {}).get("host") or "unknown-host"
+    # Sanitize host for filesystem use — colons (e.g. host:port) and slashes
+    # don't belong in directory names.
+    host = re.sub(r"[^A-Za-z0-9._-]", "_", host)
+
+    uuid_str = base64_uuid_to_str(body.get("uuid", ""))
+
+    host_dir = snapshot_dir / host
+    host_dir.mkdir(parents=True, exist_ok=True)
+    path = host_dir / f"{uuid_str}.json"
+    path.write_text(json.dumps(body, separators=(",", ":")))
+    return path
+
+
+# ─── snapshot metadata ──────────────────────────────────────────────────────
+
+
+def write_metadata(out_dir: Path, snapshot_id: str, logql: str, start: datetime, end: datetime, count: int) -> None:
+    """Write `.metadata/snapshot.json` so downstream tooling can recognize this
+    as a Speedscale-style snapshot directory.
+
+    Field shape is intentionally a subset of the cloud Scenario proto — we mark
+    `source: "loki"` and `analysisStatus: "none"` so anything that branches on
+    cloud-style analysis (which doesn't apply here) can skip cleanly.
+    """
+    meta = {
+        "id":             snapshot_id,
+        "name":           f"loki-gather-{snapshot_id[:8]}",
+        "source":         "loki",
+        "analysisStatus": "none",
+        "logql":          logql,
+        "timeRange": {
+            "start": start.astimezone(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "end":   end.astimezone(timezone.utc).isoformat().replace("+00:00", "Z"),
+        },
+        "rrpairCount":    count,
+        "createdAt":      datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "createdBy":      "loki-gather.py",
+    }
+    meta_dir = out_dir / ".metadata"
+    meta_dir.mkdir(parents=True, exist_ok=True)
+    (meta_dir / "snapshot.json").write_text(json.dumps(meta, indent=2))
+
+
+# ─── CLI ────────────────────────────────────────────────────────────────────
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        prog="loki-gather.py",
+        description="Pull a subset of BYOC RRPair traffic from Loki and write a proxymock-replayable directory.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__.split("Usage:\n", 1)[1] if "Usage:" in (__doc__ or "") else None,
+    )
+    p.add_argument("--loki-url",  required=True, help="Base URL of the Loki HTTP API (e.g. http://localhost:38030)")
+    p.add_argument("--out-dir",   required=True, help="Output directory for the proxymock snapshot tree")
+
+    p.add_argument("--start",     default="-15m", help="Window start: 'now', '-15m', '-2h', '-1d', or RFC3339. Default: -15m")
+    p.add_argument("--end",       default="now",  help="Window end: same formats as --start. Default: now")
+    p.add_argument("--limit",     type=int, default=5000, help="Max records to fetch in one query (Loki has a server-side cap, usually 5000). Default: 5000")
+
+    p.add_argument("--cluster",   help="Filter by cluster (stream label)")
+    p.add_argument("--service",   help="Filter by service (stream label)")
+    p.add_argument("--namespace", help="Filter by namespace (stream label)")
+    p.add_argument("--method",    help='Filter by HTTP method, regex (e.g. "GET", "POST|PUT")')
+    p.add_argument("--status",    help='Filter by HTTP status, regex (e.g. "200", "2..", "[45]..")')
+    p.add_argument("--endpoint",  help='Filter by URL path, regex (e.g. "^/api/.+")')
+    p.add_argument("--direction", choices=("IN", "OUT"), help="Filter by traffic direction")
+
+    p.add_argument("--logql", help="Full LogQL query — bypasses all the above filter flags. For power users.")
+
+    p.add_argument("--dry-run", action="store_true", help="Print the resolved LogQL + window and exit without querying or writing")
+
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    try:
+        start = parse_time(args.start)
+        end   = parse_time(args.end)
+    except ValueError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+
+    logql = build_logql(args)
+
+    print(f"loki-gather: {args.loki_url}", file=sys.stderr)
+    print(f"  window: {start.isoformat()}  →  {end.isoformat()}  ({(end - start).total_seconds():.0f}s)", file=sys.stderr)
+    print(f"  query:  {logql}", file=sys.stderr)
+
+    if args.dry_run:
+        print("dry run — exiting without querying Loki", file=sys.stderr)
+        return 0
+
+    try:
+        records = query_loki(args.loki_url, logql, start, end, args.limit)
+    except RuntimeError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+
+    if not records:
+        print("no traffic matched filter; nothing written.", file=sys.stderr)
+        print("hint: widen the time window, drop a filter, or use --dry-run to inspect the resolved query", file=sys.stderr)
+        return 1
+
+    # First pass: fixups (cluster=undefined, etc.) + assign instance numbers
+    # for duplicate signatures so proxymock's responder can match deterministically.
+    for stream, body in records:
+        fix_record(body, stream)
+    assign_instances(records)
+
+    out_dir = Path(args.out_dir).expanduser().resolve()
+    snapshot_id = str(uuid_mod.uuid4())
+    snapshot_dir = out_dir / f"snapshot-{snapshot_id}"
+    snapshot_dir.mkdir(parents=True, exist_ok=True)
+
+    written = 0
+    hosts: dict[str, int] = {}
+    for _stream, body in records:
+        path = write_rrpair(body, snapshot_dir)
+        host = path.parent.name
+        hosts[host] = hosts.get(host, 0) + 1
+        written += 1
+
+    write_metadata(out_dir, snapshot_id, logql, start, end, written)
+
+    print(f"wrote {written} RRPairs to {snapshot_dir}", file=sys.stderr)
+    for host, n in sorted(hosts.items(), key=lambda kv: -kv[1]):
+        print(f"  {host}: {n}", file=sys.stderr)
+    print("", file=sys.stderr)
+    print(f"replay with:  proxymock mock --in {out_dir} --listen :8080", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Single-file Python script (`reference-architectures/grafana/scripts/loki-gather.py`) that pulls a subset of RRPair traffic from Loki and writes it as a `proxymock`-replayable directory. This is the "gather" half of Speedscale Cloud's Create-Snapshot flow, sourced from Loki instead of the cloud's S3-backed snapshot store. Analysis is proxymock's job once the directory exists — this script only does the extraction.

stdlib only — no `pip install`. Drop-in for anyone running the BYOC reference architecture.

## Pattern this introduces

Companion scripts live next to the reference architecture they enable. Once we accumulate a handful (`elasticsearch/scripts/...`, `fluent-bit/scripts/...`, etc.) the pattern earns its own repo with proper packaging. For now, here is the playground. See [S-11101](https://linear.app/speedscale/issue/S-11101) for the design + phase-2 promotion path.

## Usage

```bash
kubectl -n observability port-forward svc/loki 3101:3100 &

python3 reference-architectures/grafana/scripts/loki-gather.py \
  --loki-url http://localhost:3101 \
  --start    -15m \
  --service  java-server \
  --status   2.. \
  --endpoint '^/spacex/.+' \
  --out-dir  /tmp/spacex-snapshot

proxymock mock --in /tmp/spacex-snapshot
```

CLI flags translate to LogQL stream-label and pipeline filters. Power users can bypass translation with `--logql '<query>'`.

## Output

```
<out-dir>/
├── .metadata/snapshot.json        # synthesized: id, source=loki, time window, logql
└── snapshot-<uuid>/
    ├── java-server/
    │   ├── <rrpair-uuid>.json     # one file per RRPair (proto JSON form)
    │   └── ...
    └── <other-host>/
        └── ...
```

Same shape `speedctl proxymock cloud pull snapshot` produces after expanding a cloud snapshot.

## Workarounds documented in the code

1. **`body.cluster = "undefined"`** ([S-11091](https://linear.app/speedscale/issue/S-11091)) — overwrite with the Loki stream-label `cluster`. Same for `body.namespace`.
2. **Signature `instance: N` numbering** — proxymock's responder dedupes replays via an `instance` field in the signature map. Cloud snapshots have this because the analyzer adds it during snapshot processing; we skip the analyzer (by design), so the script assigns instance numbers itself by Loki ingest order.
3. **Loki 500-series cardinality cap** — every LogQL query pipes through `| keep <small-field-list>` after `| json`. A naïve parse extracts ~60 nested fields and blows past the cap on aggregate queries.

## Verified on miniken

```
$ python3 loki-gather.py --loki-url http://localhost:3101 --service java-server --status 2.. --start -3m --out-dir /tmp/x
loki-gather: http://localhost:3101
  window: 2026-05-23T20:06:17 → 2026-05-23T20:09:17  (180s)
  query:  {service="java-server"} | json | keep cluster, service, namespace, body_command, body_status, body_location, body_direction, body_uuid, body_ts, body_duration | body_status=~"2.."
wrote 308 RRPairs to /tmp/x/snapshot-fac4f9df-0c24-4193-8091-d18d80298615
  java-server: 306
  api.fiscaldata.treasury.gov: 2
```

Sample output file has `cluster: "miniken"` (was `"undefined"` in Loki), `namespace: "speedscale"`, full HTTP req/res with base64 bodies, signatures with `instance: <N>` assigned. `proxymock mock --in <dir>` loads the files and recognizes the signatures (visible in match-attempt logs).

## Test plan

- [ ] `python3 loki-gather.py --help` prints sane help
- [ ] `--dry-run` shows the resolved query + time window without hitting Loki
- [ ] Live gather against the BYOC reference architecture produces a directory matching the documented shape
- [ ] `body.cluster` in every emitted RRPair is the cluster name from the stream label, not `"undefined"`
- [ ] Every signature has an `instance` field
- [ ] `proxymock mock --in <out-dir>` starts cleanly and loads the records (logs show signature comparison)
- [ ] Empty result prints "no traffic matched filter" and exits without writing a half-built directory

## What's NOT in this PR (deferred)

- `--md` markdown output format — `.json` is proven, markdown is phase-1.5
- Pagination / auto-windowing for large time ranges
- Auth flags (`--bearer-token`, `--basic-auth`) — add when needed
- `speedctl proxymock cloud pull loki` subcommand — phase 2, once this pattern proves itself

## Related

- [S-11080](https://linear.app/speedscale/issue/S-11080) — `byoc_otel` HTTP transport (In Review) — produces the data this consumes
- [S-11091](https://linear.app/speedscale/issue/S-11091) — `body.cluster = "undefined"` bug; this script has a workaround
- [speedscale/demo#149](https://github.com/speedscale/demo/pull/149) — Speedscale Traffic dashboard; same LogQL filter shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)