### PR TITLE
feat(grafana): NodePort services + fix RRPair logs panel cluster bug

### DIFF
--- a/reference-architectures/grafana/README.md
+++ b/reference-architectures/grafana/README.md
@@ -59,28 +59,31 @@ kubectl -n observability get pods
 - Indexing: Loki stores logs and indexed labels.
 - Visualization: Grafana Explore and dashboards.
 
+Grafana and Loki are both `Service: NodePort` (30030 and 30031 respectively) so you don't need a `kubectl port-forward` process babysitting your dev loop. Reach them via the node IP:
+
 ```bash
-kubectl -n observability port-forward svc/grafana 38030:3000
+NODE_IP=$(minikube ip)   # or: kubectl get nodes -o wide
+
+open "http://${NODE_IP}:30030"   # Grafana (admin/admin)
+curl "http://${NODE_IP}:30031/ready"   # Loki
 ```
 
-Open `http://localhost:38030` (admin/admin), then in Explore query `{source="speedscale"}`.
+In Grafana Explore, query `{source="speedscale"}`. Two dashboards are auto-provisioned under the **Speedscale BYOC** folder:
 
-Two dashboards are auto-provisioned under the **Speedscale BYOC** folder:
-
-- **Speedscale BYOC** — infra view (forwarder metrics, queue depths, raw log stream)
+- **Speedscale BYOC** — infra view (forwarder metrics, queue depths, structured RRPair log stream)
 - **Speedscale Traffic** — RRPair traffic explorer (filter by service / method / status / endpoint regex; one-line-per-request format; expand any row for the full JSON with req/res bodies)
 
-The host port `38030` is chosen to dodge the common 3000-3999 dev-server range. If you change it, change it consistently across `port-forward` and any docs that reference the URL.
+> **`minikube --driver=docker` on macOS:** the node IP `192.168.49.2` lives inside Docker Desktop's hidden VM and isn't routable from your host. Either flip on Docker Desktop's "host networking" (Settings → Resources → Network), switch to a driver where the VM IP routes natively (OrbStack, vfkit, hyperkit), or run a `socat` sidecar to bridge each port — see `speedstack/infra/minikube/speedscale-operator/install.sh` for the pattern.
 
 ## Replay (gather a subset of traffic into proxymock)
 
 Once Loki has some real traffic, you can pull any slice of it out as a directory `proxymock` reads:
 
 ```bash
-kubectl -n observability port-forward svc/loki 3101:3100 &
+NODE_IP=$(minikube ip)
 
 python3 scripts/loki-gather.py \
-  --loki-url http://localhost:3101 \
+  --loki-url http://${NODE_IP}:30031 \
   --service  java-server \
   --status   2.. \
   --endpoint '^/spacex/.+' \

--- a/reference-architectures/grafana/manifests/grafana-loki.yaml
+++ b/reference-architectures/grafana/manifests/grafana-loki.yaml
@@ -107,12 +107,16 @@ metadata:
   name: loki
   namespace: observability
 spec:
+  # NodePort so loki-gather.py can reach Loki without a kubectl port-forward.
+  # 30031 is reserved for this in speedstack/docs/port-registry.md.
+  type: NodePort
   selector:
     app: loki
   ports:
     - name: http
       port: 3100
       targetPort: 3100
+      nodePort: 30031
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -214,10 +218,14 @@ data:
         },
         {
           "type": "logs",
-          "title": "Speedscale RRPair logs (Loki)",
+          "title": "Recent RRPairs (Loki stream labels)",
+          "description": "One line per RRPair, with cluster/service pulled from Loki stream labels (which are correct). The body.cluster field on each record will read \"undefined\" until forwarder bug S-11091 lands — that's why we format from stream labels instead of dumping raw JSON.",
           "gridPos": { "h": 10, "w": 24, "x": 0, "y": 12 },
           "datasource": { "type": "loki", "uid": "loki" },
-          "targets": [{ "expr": "{cluster=\"miniken\"} |= \"\"", "refId": "A" }]
+          "targets": [{
+            "expr": "{cluster=~\".+\"} | json | keep cluster, service, body_command, body_status, body_duration, body_location, body_direction | line_format \"{{.cluster}}/{{.service}}  {{.body_direction}}  {{.body_command}} {{.body_status}} {{ printf \\\"%4s\\\" .body_duration }}ms  {{.body_location}}\"",
+            "refId": "A"
+          }]
         }
       ],
       "refresh": "10s",
@@ -552,9 +560,13 @@ metadata:
   name: grafana
   namespace: observability
 spec:
+  # NodePort so access doesn't depend on a kubectl port-forward staying alive.
+  # 30030 is reserved for this in speedstack/docs/port-registry.md.
+  type: NodePort
   selector:
     app: grafana
   ports:
     - name: http
       port: 3000
       targetPort: 3000
+      nodePort: 30030

--- a/reference-architectures/grafana/scripts/README.md
+++ b/reference-architectures/grafana/scripts/README.md
@@ -11,14 +11,14 @@ Pull a subset of RRPair traffic from Loki and write a `proxymock`-replayable dir
 ### Requirements
 
 - Python 3.9+ (stdlib only — no `pip install`)
-- A reachable Loki HTTP endpoint (typically `kubectl port-forward svc/loki 3101:3100` against the BYOC reference architecture)
+- A reachable Loki HTTP endpoint. With the BYOC reference architecture Loki is `Service: NodePort` on `30031`, so `http://$(minikube ip):30031` (or `http://<node-ip>:30031` on a real cluster) works without a `kubectl port-forward`. On `minikube --driver=docker` on macOS, route it via Docker Desktop host networking, a non-docker driver, or the `loki-bridge` socat container that `speedstack/infra/minikube/speedscale-operator/install.sh` brings up at `localhost:3101`.
 - `proxymock` if you want to replay the result
 
 ### Usage
 
 ```bash
 python3 loki-gather.py \
-  --loki-url http://localhost:3101 \
+  --loki-url http://$(minikube ip):30031 \
   --start    -15m \
   --service  java-server \
   --status   2.. \


### PR DESCRIPTION
## Summary

Two changes piled together because they were both discovered while wiring up resilient localhost access to the BYOC dashboards. Follow-up to #150 (merged).

- **Grafana and Loki Services → `type: NodePort`** with pinned ports 30030 and 30031. Reaching the dashboards no longer depends on a `kubectl port-forward` process staying alive — on every k8s platform where the node IP is routable from the host (kind, OrbStack, vfkit, hyperkit, real clusters), `\$(minikube ip):30030` Just Works.
- **READMEs updated** to use `\$(minikube ip):30030` / `:30031` as the primary access path and call out the `minikube --driver=docker` on macOS caveat (LinuxKit VM makes the node IP unroutable; companion speedstack MR adds a `socat` bridge sidecar pattern for that case).
- **Fixed the "Speedscale RRPair logs (Loki)" panel** on the BYOC infra dashboard. It was dumping raw JSON, surfacing the `body.cluster: "undefined"` forwarder bug (tracked separately) for every record. Switched to the same `line_format` pattern the Traffic dashboard uses — `cluster` and `service` pulled from Loki stream labels (which are correct), formatted one-line-per-RRPair. Also dropped the hardcoded `cluster="miniken"` filter that would have rendered empty for any other reader of this repo.

## Test plan

- [x] `kubectl apply` against miniken — both Services now NodePort, ports 30030/30031 assigned and stable across reapplies
- [x] Verified end-to-end on miniken: `\$(minikube ip):30030` reachable on driver where node IP routes; on docker-driver, reachable via companion speedstack bridge MR
- [x] Verified new RRPair logs LogQL query against live Loki — renders `miniken/outerspace-server  IN  GET 500    1ms  /api/rocket` (correct cluster from stream label, no "undefined")
- [ ] Grafana file-provider auto-reload picks up the panel change (10s poll; refresh the dashboard to see)

🤖 Generated with [Claude Code](https://claude.com/claude-code)