### PR TITLE
ci(php): cut noise on non-PHP PRs + stop false-failing on abandoned deps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,7 +69,10 @@ jobs:
       working-directory: php
       run: |
         composer install --no-interaction --no-progress --prefer-dist
-        composer audit
+        # --abandoned=report: only fail on real security advisories. Don't
+        # fail the build just because a transitive phpunit dep is marked
+        # abandoned — matches semantics of bundle-audit / npm audit above.
+        composer audit --abandoned=report
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -3,6 +3,15 @@ name: PHP CI
 on:
   pull_request:
     branches: [ master ]
+    # Only run when something that actually affects the PHP build changes.
+    # Without this, every PR to master (terraform, k8s charts, ruby/java
+    # demos, docs) shows red checks from this workflow even though no PHP
+    # code was touched.
+    paths:
+      - 'php/**'
+      - '.github/workflows/php-ci.yml'
+      - 'Makefile'
+      - 'VERSION'
 
 jobs:
   test-php:
@@ -30,7 +39,10 @@ jobs:
 
       - name: Composer audit (security)
         working-directory: php
-        run: composer audit
+        # --abandoned=report: only fail on real security advisories. Don't
+        # fail the build just because a transitive phpunit dep is marked
+        # abandoned (e.g. sebastian/code-unit) — that's not a vulnerability.
+        run: composer audit --abandoned=report
 
       - name: Run tests
         working-directory: php
@@ -54,7 +66,10 @@ jobs:
 
       - name: Composer audit (security)
         working-directory: php
-        run: composer audit
+        # --abandoned=report: only fail on real security advisories. Don't
+        # fail the build just because a transitive phpunit dep is marked
+        # abandoned (e.g. sebastian/code-unit) — that's not a vulnerability.
+        run: composer audit --abandoned=report
 
       - name: Build project via Makefile
         run: make build-php


### PR DESCRIPTION
# Problem

PHP CI ran the `test-php`, `build-php`, and `dependency-security` jobs on every PR to master regardless of whether PHP code was touched. Recent PRs for reference-architecture changes, terraform, k8s charts, and other non-PHP demos all showed 3 red checks from this workflow.

Two separate issues:

1. **No path filtering** — `.github/workflows/php-ci.yml` had no `paths:` filter on its `pull_request` trigger, so it fired on every PR.
2. **`composer audit` exit code 2** — both `php-ci.yml` and the `dependency-security` job in `ci.yaml` ran bare `composer audit`. Recent composer versions exit non-zero when they find _abandoned_ packages, even with no security advisories. Two transitive deps of `phpunit/phpunit` are marked abandoned upstream (`sebastian/code-unit`, `sebastian/code-unit-reverse-lookup`), so the audit step was failing on every run despite there being zero actual CVEs.

# Solution

- `php-ci.yml`: add a `paths:` filter scoped to `php/**`, the workflow itself, top-level `Makefile`, and `VERSION` (which `php/Makefile` reads).
- Both workflows: change `composer audit` → `composer audit --abandoned=report`. Abandoned packages are still surfaced in the log; only real security advisories fail the build.

No PHP dependency bumps were needed. The 5 open Dependabot alerts on the repo (2 high, 3 moderate) are all in **ruby/java/pip** ecosystems — none in composer. `composer audit` against `php/composer.lock` returns no security advisories.

## Checklist
- [x] Verified `composer audit --abandoned=report` exits 0 locally on `php/composer.lock` with the abandoned-package warning still printed
- [x] Verified no composer-ecosystem Dependabot alerts on the repo
- [x] Path filter covers everything `make build-php` touches (`php/**`, `Makefile`, `VERSION`)
- [x] Workflow YAML parses

🤖 Generated with [Claude Code](https://claude.com/claude-code)