### PR TITLE
feat(fluent-bit): add BigQuery + Looker Studio query/visualize layer

### DIFF
--- a/reference-architectures/fluent-bit/README.md
+++ b/reference-architectures/fluent-bit/README.md
@@ -20,17 +20,26 @@ flowchart LR
     FB[Fluent Bit<br/>opentelemetry input :4318]
   end
   GCS[(GCS bucket<br/>NDJSON.gz objects)]
+  subgraph BQ[BigQuery + Looker Studio]
+    Ext[rrpair_ext<br/>external table]
+    View[rrpair_view<br/>flattened]
+    Looker[Looker Studio<br/>dashboards]
+  end
 
   Apps --> Cap --> Fwd
   Fwd -->|OTLP gRPC| OTel
   OTel -->|OTLP HTTP| FB
   FB -->|PutObject<br/>XML API| GCS
+  GCS -.->|read-on-query<br/>no copy| Ext
+  Ext --> View --> Looker
 ```
 
 `byoc-grafana` and `byoc-elasticsearch` (sibling scenarios) are live-query
 backends — you see traffic in a dashboard. This scenario is the **archive**
 path: data lands as partitioned NDJSON objects in GCS, ready for cheap
-long-term retention and batch consumption.
+long-term retention and batch consumption. The optional BigQuery layer
+(`bq/` — external tables, no data copy) bolts SQL + Looker Studio onto the
+same bucket without paying for BQ storage.
 
 ## Why pick this over `byoc-grafana/` or `byoc-elasticsearch/`?
 
@@ -201,6 +210,55 @@ What the script does:
 
 Pass `--dry-run` to see which partitions and objects the window touches
 before downloading anything.
+
+## Query + visualize (BigQuery + Looker Studio)
+
+The `bq/` directory wires the GCS bucket into BigQuery as an **external
+table** — no data is copied into BigQuery storage, queries read GCS
+directly. The first 1 TB/month of bytes scanned is free; at demo
+volumes every query rounds to $0.
+
+```bash
+./bq/setup.sh <project-id> <bucket-name>
+# Example:
+./bq/setup.sh speedscale-demos speedscale-rrpair-demo
+```
+
+That creates:
+
+- **Dataset** `speedscale_rrpair` (us-central1, colocated with the bucket).
+- **External table** `rrpair_ext` over the Hive-partitioned bucket.
+  `require_hive_partition_filter = TRUE` forces every query to include
+  `WHERE year=… AND month=…` — without it, queries fail rather than
+  full-scan the bucket. Nested fields (`http`, `tags`, etc.) keep their
+  structure as `JSON` columns.
+- **Flattened view** `rrpair_view` that pre-extracts the commonly-queried
+  fields (`request_time`, `method`, `status_code`, `host`, `path`,
+  `duration_ms`, `app_label`, …) into flat typed columns ready for BI
+  tools.
+
+Sample query:
+
+```sql
+SELECT host, path, method,
+       COUNT(*)                                       AS reqs,
+       APPROX_QUANTILES(duration_ms, 100)[OFFSET(95)] AS p95_ms
+FROM `<project>.speedscale_rrpair.rrpair_view`
+WHERE year=2026 AND month=5 AND day=25
+GROUP BY host, path, method
+ORDER BY reqs DESC;
+```
+
+To visualize, open Looker Studio (free) with the data source pre-wired
+to the view:
+
+```
+https://lookerstudio.google.com/reporting/create?c.reportId=&ds.ds0.connector=bigQuery&ds.ds0.projectId=<PROJECT_ID>&ds.ds0.type=TABLE&ds.ds0.datasetId=speedscale_rrpair&ds.ds0.tableId=rrpair_view
+```
+
+`bq/setup.sh` prints this URL with your project filled in. See `bq/README.md`
+for suggested chart layout (requests-over-time, status mix, top endpoints,
+p50/p95/p99 latency scorecards).
 
 ## Version pins
 

--- a/reference-architectures/fluent-bit/README.md
+++ b/reference-architectures/fluent-bit/README.md
@@ -20,10 +20,10 @@ flowchart LR
     FB[Fluent Bit<br/>opentelemetry input :4318]
   end
   GCS[(GCS bucket<br/>NDJSON.gz objects)]
-  subgraph BQ[BigQuery + Looker Studio]
+  subgraph BQ[BigQuery + Data Studio]
     Ext[rrpair_ext<br/>external table]
     View[rrpair_view<br/>flattened]
-    Looker[Looker Studio<br/>dashboards]
+    DS[Data Studio<br/>dashboards]
   end
 
   Apps --> Cap --> Fwd
@@ -31,14 +31,14 @@ flowchart LR
   OTel -->|OTLP HTTP| FB
   FB -->|PutObject<br/>XML API| GCS
   GCS -.->|read-on-query<br/>no copy| Ext
-  Ext --> View --> Looker
+  Ext --> View --> DS
 ```
 
 `byoc-grafana` and `byoc-elasticsearch` (sibling scenarios) are live-query
 backends — you see traffic in a dashboard. This scenario is the **archive**
 path: data lands as partitioned NDJSON objects in GCS, ready for cheap
 long-term retention and batch consumption. The optional BigQuery layer
-(`bq/` — external tables, no data copy) bolts SQL + Looker Studio onto the
+(`bq/` — external tables, no data copy) bolts SQL + Data Studio onto the
 same bucket without paying for BQ storage.
 
 ## Why pick this over `byoc-grafana/` or `byoc-elasticsearch/`?
@@ -211,7 +211,7 @@ What the script does:
 Pass `--dry-run` to see which partitions and objects the window touches
 before downloading anything.
 
-## Query + visualize (BigQuery + Looker Studio)
+## Query + visualize (BigQuery + Data Studio)
 
 The `bq/` directory wires the GCS bucket into BigQuery as an **external
 table** — no data is copied into BigQuery storage, queries read GCS
@@ -249,11 +249,11 @@ GROUP BY host, path, method
 ORDER BY reqs DESC;
 ```
 
-To visualize, open Looker Studio (free) with the data source pre-wired
+To visualize, open Data Studio (free) with the data source pre-wired
 to the view:
 
 ```
-https://lookerstudio.google.com/reporting/create?c.reportId=&ds.ds0.connector=bigQuery&ds.ds0.projectId=<PROJECT_ID>&ds.ds0.type=TABLE&ds.ds0.datasetId=speedscale_rrpair&ds.ds0.tableId=rrpair_view
+https://datastudio.google.com/reporting/create?c.reportId=&ds.ds0.connector=bigQuery&ds.ds0.projectId=<PROJECT_ID>&ds.ds0.type=TABLE&ds.ds0.datasetId=speedscale_rrpair&ds.ds0.tableId=rrpair_view
 ```
 
 `bq/setup.sh` prints this URL with your project filled in. See `bq/README.md`

--- a/reference-architectures/fluent-bit/README.md
+++ b/reference-architectures/fluent-bit/README.md
@@ -249,16 +249,22 @@ GROUP BY host, path, method
 ORDER BY reqs DESC;
 ```
 
-To visualize, open Data Studio (free) with the data source pre-wired
-to the view:
+To visualize, open Data Studio (free) and connect the BigQuery view as
+your data source:
 
-```
-https://datastudio.google.com/reporting/create?c.reportId=&ds.ds0.connector=bigQuery&ds.ds0.projectId=<PROJECT_ID>&ds.ds0.type=TABLE&ds.ds0.datasetId=speedscale_rrpair&ds.ds0.tableId=rrpair_view
-```
+1. Go to https://datastudio.google.com and sign in.
+2. Click **Create** → **Report** (or "Blank Report").
+3. In the "Add data to report" panel, pick the **BigQuery** connector
+   (authorize it if prompted on first use).
+4. Browse to your project → `speedscale_rrpair` → `rrpair_view` → **Add**.
 
-`bq/setup.sh` prints this URL with your project filled in. See `bq/README.md`
-for suggested chart layout (requests-over-time, status mix, top endpoints,
-p50/p95/p99 latency scorecards).
+See `bq/README.md` for suggested chart layout (requests-over-time, status
+mix, top endpoints, p50/p95/p99 latency scorecards).
+
+> Note: Data Studio's Linking API can only deep-link into pre-existing
+> *template* reports (cloning + overriding a data source by alias). It
+> does not support the "create a brand-new blank report with this data
+> source" pattern, so the docs here use the manual add-data flow.
 
 ## Version pins
 

--- a/reference-architectures/fluent-bit/README.md
+++ b/reference-architectures/fluent-bit/README.md
@@ -258,8 +258,15 @@ your data source:
    (authorize it if prompted on first use).
 4. Browse to your project → `speedscale_rrpair` → `rrpair_view` → **Add**.
 
-See `bq/README.md` for suggested chart layout (requests-over-time, status
-mix, top endpoints, p50/p95/p99 latency scorecards).
+A pre-built reference dashboard against the canonical demo bucket
+(`gs://speedscale-rrpair-demo`) lives at:
+
+> https://datastudio.google.com/reporting/74795188-ddc0-41ac-ad5a-d53df0d1b022
+
+It includes requests-over-time, status mix, top endpoints, p50/p95/p99
+latency scorecards, by-service breakdown, and capture-mode mix. See
+`bq/README.md` for the click-by-click build instructions if you want to
+recreate it against your own bucket.
 
 > Note: Data Studio's Linking API can only deep-link into pre-existing
 > *template* reports (cloning + overriding a data source by alias). It

--- a/reference-architectures/fluent-bit/bq/001-dataset.sql
+++ b/reference-architectures/fluent-bit/bq/001-dataset.sql
@@ -1,0 +1,14 @@
+-- 001 — BigQuery dataset for the Fluent Bit RRPair data lake.
+--
+-- Colocated in the same region as the GCS bucket (us-central1) so external
+-- table queries don't incur cross-region egress. No native BigQuery storage
+-- ever lives here — only external tables that read directly from GCS.
+--
+-- Run with:
+--   bq --project_id=<your-project> query --use_legacy_sql=false < 001-dataset.sql
+
+CREATE SCHEMA IF NOT EXISTS speedscale_rrpair
+OPTIONS (
+  location = 'us-central1',
+  description = 'External tables over the Fluent Bit BYOC RRPair data lake. Schema is external-only — no native BigQuery storage cost; queries pay only for bytes scanned in GCS (with the 1 TB/month free tier).'
+);

--- a/reference-architectures/fluent-bit/bq/002-external-table.sql
+++ b/reference-architectures/fluent-bit/bq/002-external-table.sql
@@ -1,0 +1,62 @@
+-- 002 — External table over the Hive-partitioned GCS bucket.
+--
+-- Fluent Bit writes gs://<bucket>/year=YYYY/month=MM/day=DD/hour=HH/<uuid>.json.gz
+-- One OTLP LogRecord per NDJSON line, with the RRPair body flattened to the
+-- top level (FB's `s3` JSON output emits records that way).
+--
+-- Schema notes:
+--   - `@timestamp` and `__internal__` are present in each JSON record but
+--     omitted from the schema (BQ column names can't start with `@` or
+--     contain dots). `ignore_unknown_values = TRUE` makes BQ skip them
+--     silently rather than reject the row.
+--   - Nested objects (http, tags, netinfo, signature) land as JSON type so
+--     ad-hoc queries can drill in via JSON_VALUE / dot accessors. The
+--     `rrpair_view` (003) pre-extracts the common fields for BI tooling.
+--   - `require_hive_partition_filter = TRUE` is a safety belt: every query
+--     MUST include `WHERE year=… AND month=…` (and ideally day/hour).
+--     Without it, queries fail rather than full-scan the bucket.
+--
+-- Set the @bucket and @project_id query parameters at run time:
+--   bq query --use_legacy_sql=false \
+--      --parameter='project_id::your-project' \
+--      --parameter='bucket::your-bucket' \
+--      < 002-external-table.sql
+--
+-- Or substitute inline before running.
+
+CREATE OR REPLACE EXTERNAL TABLE `speedscale_rrpair.rrpair_ext` (
+  service      STRING,
+  namespace    STRING,
+  cluster      STRING,
+  command      STRING,                -- HTTP method
+  status       STRING,                -- HTTP status as string ("200")
+  location     STRING,                -- URL path
+  duration     FLOAT64,               -- ms
+  direction    STRING,                -- IN / OUT
+  msgType      STRING,                -- always "rrpair"
+  tech         STRING,                -- payload tech (JSON, etc.)
+  l7protocol   STRING,                -- http, grpc, etc.
+  resource     STRING,
+  uuid         STRING,                -- base64 16-byte RRPair UUID
+  ts           STRING,                -- RFC3339 nanosecond timestamp
+  dlpModified  BOOL,
+  dlpRule      STRING,
+  http         JSON,                  -- {req, res}
+  tags         JSON,                  -- k8s pod/app metadata
+  netinfo      JSON,                  -- upstream/downstream IP:port
+  signature    JSON                   -- proxymock signature
+)
+WITH PARTITION COLUMNS (
+  year   INT64,
+  month  INT64,
+  day    INT64,
+  hour   INT64
+)
+OPTIONS (
+  format = 'JSON',
+  uris = ['gs://speedscale-rrpair-demo/*'],
+  hive_partition_uri_prefix = 'gs://speedscale-rrpair-demo/',
+  require_hive_partition_filter = TRUE,
+  ignore_unknown_values = TRUE,
+  description = 'Speedscale RRPair traffic shipped by Fluent Bit (gs://speedscale-rrpair-demo). Hive-partitioned by year/month/day/hour. Every query MUST filter by partition.'
+);

--- a/reference-architectures/fluent-bit/bq/003-flattened-view.sql
+++ b/reference-architectures/fluent-bit/bq/003-flattened-view.sql
@@ -1,0 +1,49 @@
+-- 003 — Flattened view for BI tooling (Looker Studio, Sheets, etc.).
+--
+-- The raw `rrpair_ext` external table keeps nested objects as JSON columns
+-- (http, tags, netinfo, signature) — efficient for storage but awkward in
+-- drag-and-drop dashboards that don't speak JSON_VALUE. This view extracts
+-- the common fields into flat typed columns so Looker Studio sees them as
+-- ordinary dimensions/metrics.
+--
+-- Notes:
+--   - `request_time` truncates the RRPair's nanosecond `ts` to microsecond
+--     precision (BQ TIMESTAMP max precision) via regex strip.
+--   - `status_code` SAFE-casts the string status to INT64 (so chart math
+--     works) and returns NULL on non-numeric values rather than failing.
+--   - Partition columns (year/month/day/hour) are passed through so
+--     dashboards can build date filters without joining back to the table.
+
+CREATE OR REPLACE VIEW `speedscale_rrpair.rrpair_view` AS
+SELECT
+  TIMESTAMP(REGEXP_REPLACE(ts, r'(\.\d{6})\d+', r'\1'))           AS request_time,
+  service,
+  namespace,
+  cluster,
+  command                                                          AS method,
+  status,
+  SAFE_CAST(status AS INT64)                                       AS status_code,
+  location                                                         AS path,
+  duration                                                         AS duration_ms,
+  direction,
+  l7protocol,
+  -- HTTP request fields
+  JSON_VALUE(http.req.host)                                        AS host,
+  JSON_VALUE(http.req.url)                                         AS url,
+  JSON_VALUE(http.req.version)                                     AS http_version,
+  -- HTTP response fields
+  JSON_VALUE(http.res.statusCode)                                  AS res_status_code,
+  JSON_VALUE(http.res.contentType)                                 AS res_content_type,
+  JSON_VALUE(http.res.headers["Content-Length"][0])                AS res_content_length,
+  -- Tags (k8s metadata, capture mode)
+  JSON_VALUE(tags.k8sAppLabel)                                     AS app_label,
+  JSON_VALUE(tags.k8sAppPodName)                                   AS pod_name,
+  JSON_VALUE(tags.k8sAppPodNamespace)                              AS pod_namespace,
+  JSON_VALUE(tags.captureMode)                                     AS capture_mode,
+  JSON_VALUE(tags.proxyId)                                         AS proxy_id,
+  JSON_VALUE(tags.proxyVersion)                                    AS proxy_version,
+  -- Identifiers
+  uuid,
+  -- Partition columns passed through for date filters in dashboards
+  year, month, day, hour
+FROM `speedscale_rrpair.rrpair_ext`;

--- a/reference-architectures/fluent-bit/bq/003-flattened-view.sql
+++ b/reference-architectures/fluent-bit/bq/003-flattened-view.sql
@@ -1,9 +1,9 @@
--- 003 — Flattened view for BI tooling (Looker Studio, Sheets, etc.).
+-- 003 — Flattened view for BI tooling (Data Studio, Sheets, etc.).
 --
 -- The raw `rrpair_ext` external table keeps nested objects as JSON columns
 -- (http, tags, netinfo, signature) — efficient for storage but awkward in
 -- drag-and-drop dashboards that don't speak JSON_VALUE. This view extracts
--- the common fields into flat typed columns so Looker Studio sees them as
+-- the common fields into flat typed columns so Data Studio sees them as
 -- ordinary dimensions/metrics.
 --
 -- Notes:

--- a/reference-architectures/fluent-bit/bq/README.md
+++ b/reference-architectures/fluent-bit/bq/README.md
@@ -1,9 +1,9 @@
-# BigQuery + Looker Studio layer for the Fluent Bit data lake
+# BigQuery + Data Studio layer for the Fluent Bit data lake
 
 Fluent Bit ships RRPair logs to GCS as Hive-partitioned NDJSON. This
 directory wires that bucket into BigQuery as an **external table** (no data
 duplication, no BigQuery storage cost) and a **flattened view** that's
-ready to drop into Looker Studio.
+ready to drop into Data Studio.
 
 ```
 GCS bucket  ──(external table, no copy)──>  BigQuery
@@ -13,7 +13,7 @@ GCS bucket  ──(external table, no copy)──>  BigQuery
                                                 └──▶  rrpair_view  (flat columns for BI)
                                                                 │
                                                                 ▼
-                                                         Looker Studio
+                                                         Data Studio
 ```
 
 ## Cost
@@ -53,7 +53,7 @@ The script runs the three SQL files in order:
    `ignore_unknown_values = TRUE`.
 3. **`003-flattened-view.sql`** — creates `rrpair_view` that pre-extracts
    the commonly-queried fields (host, path, status_code, app_label, etc.)
-   into flat typed columns. This is what Looker Studio talks to.
+   into flat typed columns. This is what Data Studio talks to.
 
 Re-running the script is safe — every statement is `CREATE OR REPLACE` /
 `CREATE SCHEMA IF NOT EXISTS`.
@@ -102,20 +102,20 @@ GROUP BY host, path
 ORDER BY reqs DESC;
 ```
 
-## Visualize in Looker Studio
+## Visualize in Data Studio
 
-Looker Studio is free; the connector to BigQuery is built in. Two ways
+Data Studio is free; the connector to BigQuery is built in. Two ways
 to start:
 
 1. **Pre-wired link** (data source already pointed at `rrpair_view`):
 
    ```
-   https://lookerstudio.google.com/reporting/create?c.reportId=&ds.ds0.connector=bigQuery&ds.ds0.projectId=<PROJECT_ID>&ds.ds0.type=TABLE&ds.ds0.datasetId=speedscale_rrpair&ds.ds0.tableId=rrpair_view
+   https://datastudio.google.com/reporting/create?c.reportId=&ds.ds0.connector=bigQuery&ds.ds0.projectId=<PROJECT_ID>&ds.ds0.type=TABLE&ds.ds0.datasetId=speedscale_rrpair&ds.ds0.tableId=rrpair_view
    ```
 
    `setup.sh` prints this URL with your project filled in.
 
-2. **From scratch** — go to https://lookerstudio.google.com → Blank
+2. **From scratch** — go to https://datastudio.google.com → Blank
    Report → Add data → BigQuery → pick `rrpair_view`.
 
 ### Suggested charts
@@ -137,7 +137,7 @@ on `app_label` so viewers can scope the dashboard to one service.
 
 ### Sharing
 
-Once the report exists in Looker Studio, share it like any Google doc:
+Once the report exists in Data Studio, share it like any Google doc:
 **File → Share → "Get link"** → set to your org or specific viewers. The
 underlying BigQuery permissions still apply — viewers need at least
 `roles/bigquery.dataViewer` on the dataset to render the charts.

--- a/reference-architectures/fluent-bit/bq/README.md
+++ b/reference-architectures/fluent-bit/bq/README.md
@@ -104,7 +104,17 @@ ORDER BY reqs DESC;
 
 ## Visualize in Data Studio
 
-Data Studio is free; the BigQuery connector is built in. Setup:
+**Reference dashboard** (built against the canonical demo bucket
+`gs://speedscale-rrpair-demo`):
+
+> https://datastudio.google.com/reporting/74795188-ddc0-41ac-ad5a-d53df0d1b022
+
+Viewers need either `roles/bigquery.dataViewer` on the
+`speedscale-demos.speedscale_rrpair` dataset, OR the dashboard owner
+sets the data source to use "Owner's credentials" so any link viewer
+can see the data.
+
+To build your own (against your own bucket):
 
 1. Go to https://datastudio.google.com and sign in.
 2. Click **Create** → **Report** (or "Blank Report").

--- a/reference-architectures/fluent-bit/bq/README.md
+++ b/reference-architectures/fluent-bit/bq/README.md
@@ -1,0 +1,143 @@
+# BigQuery + Looker Studio layer for the Fluent Bit data lake
+
+Fluent Bit ships RRPair logs to GCS as Hive-partitioned NDJSON. This
+directory wires that bucket into BigQuery as an **external table** (no data
+duplication, no BigQuery storage cost) and a **flattened view** that's
+ready to drop into Looker Studio.
+
+```
+GCS bucket  ──(external table, no copy)──>  BigQuery
+                                                │
+                                                ├──▶  rrpair_ext   (raw + JSON columns)
+                                                │
+                                                └──▶  rrpair_view  (flat columns for BI)
+                                                                │
+                                                                ▼
+                                                         Looker Studio
+```
+
+## Cost
+
+External tables incur **zero BigQuery storage cost** — BQ reads directly
+from GCS at query time. You pay only for bytes scanned (`$6.25 / TB`), with
+the **first 1 TB per month free**. At demo-scale volumes (KB–MB), every
+query rounds to $0.
+
+The `require_hive_partition_filter = TRUE` option on the table forces
+every query to include `WHERE year=… AND month=…` (and ideally `day` /
+`hour`) — without it, queries fail rather than full-scan the bucket. This
+is the safety belt against accidental large scans if the bucket grows.
+
+## Setup
+
+One-time, per `(project, bucket)`:
+
+```bash
+./setup.sh <project-id> <bucket-name>
+```
+
+Example for the canonical demo bucket:
+
+```bash
+./setup.sh speedscale-demos speedscale-rrpair-demo
+```
+
+The script runs the three SQL files in order:
+
+1. **`001-dataset.sql`** — creates the `speedscale_rrpair` dataset in
+   `us-central1` (matches the bucket region so queries don't cross-region).
+2. **`002-external-table.sql`** — creates `rrpair_ext` over the bucket,
+   declaring an explicit schema. Nested fields stay as `JSON` columns;
+   unknown fields (`@timestamp`, `__internal__` — both have characters BQ
+   can't use as column names) are silently ignored via
+   `ignore_unknown_values = TRUE`.
+3. **`003-flattened-view.sql`** — creates `rrpair_view` that pre-extracts
+   the commonly-queried fields (host, path, status_code, app_label, etc.)
+   into flat typed columns. This is what Looker Studio talks to.
+
+Re-running the script is safe — every statement is `CREATE OR REPLACE` /
+`CREATE SCHEMA IF NOT EXISTS`.
+
+## Query examples
+
+Raw table — drop into the deep JSON for one-off questions:
+
+```sql
+-- Status code mix per service for a given day
+SELECT
+  service,
+  status,
+  COUNT(*) AS reqs,
+  ROUND(AVG(duration), 2) AS avg_dur_ms
+FROM `speedscale_rrpair.rrpair_ext`
+WHERE year=2026 AND month=5 AND day=25
+GROUP BY service, status
+ORDER BY reqs DESC;
+
+-- Drill into JSON: top URL paths
+SELECT
+  JSON_VALUE(http.req.url) AS url,
+  COUNT(*) AS hits
+FROM `speedscale_rrpair.rrpair_ext`
+WHERE year=2026 AND month=5 AND day=25
+GROUP BY url
+ORDER BY hits DESC
+LIMIT 20;
+```
+
+Flattened view — for dashboards and routine queries:
+
+```sql
+-- Latency percentiles per endpoint
+SELECT
+  host,
+  path,
+  APPROX_QUANTILES(duration_ms, 100)[OFFSET(50)] AS p50,
+  APPROX_QUANTILES(duration_ms, 100)[OFFSET(95)] AS p95,
+  APPROX_QUANTILES(duration_ms, 100)[OFFSET(99)] AS p99,
+  COUNT(*) AS reqs
+FROM `speedscale_rrpair.rrpair_view`
+WHERE year=2026 AND month=5 AND day=25
+GROUP BY host, path
+ORDER BY reqs DESC;
+```
+
+## Visualize in Looker Studio
+
+Looker Studio is free; the connector to BigQuery is built in. Two ways
+to start:
+
+1. **Pre-wired link** (data source already pointed at `rrpair_view`):
+
+   ```
+   https://lookerstudio.google.com/reporting/create?c.reportId=&ds.ds0.connector=bigQuery&ds.ds0.projectId=<PROJECT_ID>&ds.ds0.type=TABLE&ds.ds0.datasetId=speedscale_rrpair&ds.ds0.tableId=rrpair_view
+   ```
+
+   `setup.sh` prints this URL with your project filled in.
+
+2. **From scratch** — go to https://lookerstudio.google.com → Blank
+   Report → Add data → BigQuery → pick `rrpair_view`.
+
+### Suggested charts
+
+A useful starter dashboard for traffic exploration (5 minutes of drag-and-
+drop in the UI):
+
+| Chart | Type | Dimension(s) | Metric |
+|---|---|---|---|
+| **Requests over time** | Time-series | `request_time` (by hour) | Record Count |
+| **Status code breakdown** | Pie / donut | `status_code` | Record Count |
+| **Top endpoints** | Table | `host`, `path`, `method` | Record Count, AVG(`duration_ms`) |
+| **Latency p50/p95/p99** | Scorecard ×3 | — | Percentile(`duration_ms`) at 50/95/99 |
+| **By service** | Stacked bar | `app_label`, `status_code` | Record Count |
+| **Capture mode mix** | Pie | `capture_mode` (eBPF vs sidecar) | Record Count |
+
+Add a **date range control** on `request_time` and a **drop-down filter**
+on `app_label` so viewers can scope the dashboard to one service.
+
+### Sharing
+
+Once the report exists in Looker Studio, share it like any Google doc:
+**File → Share → "Get link"** → set to your org or specific viewers. The
+underlying BigQuery permissions still apply — viewers need at least
+`roles/bigquery.dataViewer` on the dataset to render the charts.

--- a/reference-architectures/fluent-bit/bq/README.md
+++ b/reference-architectures/fluent-bit/bq/README.md
@@ -104,19 +104,25 @@ ORDER BY reqs DESC;
 
 ## Visualize in Data Studio
 
-Data Studio is free; the connector to BigQuery is built in. Two ways
-to start:
+Data Studio is free; the BigQuery connector is built in. Setup:
 
-1. **Pre-wired link** (data source already pointed at `rrpair_view`):
+1. Go to https://datastudio.google.com and sign in.
+2. Click **Create** → **Report** (or "Blank Report").
+3. In the "Add data to report" panel, search/pick the **BigQuery**
+   connector. Authorize it on first use.
+4. Browse to your project → `speedscale_rrpair` → `rrpair_view` → **Add**.
 
-   ```
-   https://datastudio.google.com/reporting/create?c.reportId=&ds.ds0.connector=bigQuery&ds.ds0.projectId=<PROJECT_ID>&ds.ds0.type=TABLE&ds.ds0.datasetId=speedscale_rrpair&ds.ds0.tableId=rrpair_view
-   ```
+You're now in the report editor with `rrpair_view`'s columns available
+in the right-hand fields pane.
 
-   `setup.sh` prints this URL with your project filled in.
-
-2. **From scratch** — go to https://datastudio.google.com → Blank
-   Report → Add data → BigQuery → pick `rrpair_view`.
+> **Why no deep-link?** Data Studio's Linking API can only deep-link
+> into pre-existing *template* reports (cloning a template + overriding
+> its data sources by alias — `ds.ds0.*` refers to a `ds0` alias the
+> template already has). There's no documented form for "create a
+> brand-new blank report with this data source pre-attached," so we
+> use the manual add-data flow above. If/when Speedscale publishes a
+> public Data Studio template report, a deep-link clone URL becomes
+> possible.
 
 ### Suggested charts
 

--- a/reference-architectures/fluent-bit/bq/README.md
+++ b/reference-architectures/fluent-bit/bq/README.md
@@ -124,22 +124,109 @@ in the right-hand fields pane.
 > public Data Studio template report, a deep-link clone URL becomes
 > possible.
 
-### Suggested charts
+### Starter dashboard — click-by-click
 
-A useful starter dashboard for traffic exploration (5 minutes of drag-and-
-drop in the UI):
+You should be in an empty report editor with `rrpair_view` connected as
+the data source. The right pane lists every column under "Available
+fields." The center is your canvas. Build the six widgets below; each
+takes 20-40 seconds.
 
-| Chart | Type | Dimension(s) | Metric |
-|---|---|---|---|
-| **Requests over time** | Time-series | `request_time` (by hour) | Record Count |
-| **Status code breakdown** | Pie / donut | `status_code` | Record Count |
-| **Top endpoints** | Table | `host`, `path`, `method` | Record Count, AVG(`duration_ms`) |
-| **Latency p50/p95/p99** | Scorecard ×3 | — | Percentile(`duration_ms`) at 50/95/99 |
-| **By service** | Stacked bar | `app_label`, `status_code` | Record Count |
-| **Capture mode mix** | Pie | `capture_mode` (eBPF vs sidecar) | Record Count |
+**1. Date-range control** *(always add this first — every chart honors it)*
 
-Add a **date range control** on `request_time` and a **drop-down filter**
-on `app_label` so viewers can scope the dashboard to one service.
+- Top toolbar: **Add a control** → **Date range control**.
+- Drag it to the top of the canvas.
+- In the right pane: **Date range dimension** = `request_time`.
+- Set "Default date range" to **Last 7 days** (or whatever fits).
+
+**2. Service filter (drop-down)**
+
+- Toolbar: **Add a control** → **Drop-down list**.
+- Place it next to the date-range control.
+- Control field: `app_label`.
+- Lets viewers scope the whole dashboard to one service.
+
+**3. Requests over time** *(time-series line chart)*
+
+- Toolbar: **Add a chart** → under "Time series" pick the plain line chart.
+- Drag a rectangle on the canvas (≈ full width, ¼ height).
+- Right pane:
+  - **Date range dimension**: `request_time`
+  - **Dimension**: `request_time` (it will auto-bucket by hour; change to
+    "Date Hour" if you want explicit control)
+  - **Metric**: drag in `Record Count` (auto-generated)
+- Optional: **Breakdown dimension** = `status_code` to color-split lines.
+
+**4. Status code breakdown** *(donut)*
+
+- **Add a chart** → "Pie chart" → pick the donut variant.
+- Place top-right, square.
+- **Dimension**: `status_code`
+- **Metric**: `Record Count`
+- In the **Style** tab: turn on "Show labels" → "Percentage".
+
+**5. Top endpoints** *(table)*
+
+- **Add a chart** → "Table".
+- Place under the time-series chart, ~⅔ width.
+- **Dimensions** (in order): `host`, `path`, `method`
+- **Metrics**:
+  - `Record Count` — rename to "Requests" in the Style tab
+  - `duration_ms` with **aggregation = Average** — rename to "Avg ms"
+- Sort: by Requests, **Descending**. Rows per page: 25.
+
+**6. Latency percentiles** *(three scorecards side-by-side)*
+
+For each scorecard:
+- **Add a chart** → "Scorecard".
+- Place three small cards in a row beside the donut.
+- **Metric**: `duration_ms`. Click the metric → **Aggregation: Custom →
+  APPROX_QUANTILES** is not available in the UI, so use this trick:
+  - Click the metric pencil icon → switch to a **Calculated field**:
+    - p50: `APPROX_QUANTILES(duration_ms, 100)[OFFSET(50)]`
+    - p95: `APPROX_QUANTILES(duration_ms, 100)[OFFSET(95)]`
+    - p99: `APPROX_QUANTILES(duration_ms, 100)[OFFSET(99)]`
+  - Name each one accordingly; they appear back in the field list and
+    can be reused across charts.
+- Label each card "p50 ms", "p95 ms", "p99 ms" in the **Style** tab.
+
+**7. By service** *(stacked horizontal bar)*
+
+- **Add a chart** → "Bar chart" → horizontal stacked.
+- Place beside the table.
+- **Dimension**: `app_label`
+- **Breakdown dimension**: `status_code`
+- **Metric**: `Record Count`
+- Sort: by Record Count desc.
+
+**8. Capture mode mix** *(pie, small)*
+
+- **Add a chart** → "Pie chart".
+- Place in a corner.
+- **Dimension**: `capture_mode`
+- **Metric**: `Record Count`
+- Useful sanity check that the eBPF nettap is doing the work (you should
+  see ~100% `eBPF`).
+
+**Polish**
+
+- Rename the report (top-left "Untitled Report") to something like
+  "Speedscale RRPair Traffic".
+- File → Report settings → Default data source: `rrpair_view`.
+- **View** mode (top-right toggle) hides the editor chrome — that's
+  what viewers see.
+
+**Troubleshooting**
+
+- **"There was a problem"** on a chart usually means the query is
+  missing the partition filter. Right pane → "Filter" → add
+  `year Equal to 2026` (or whatever range you want). The Date-range
+  control set up in step 1 normally handles this through
+  `request_time`, but if you build charts before the control is wired
+  up, charts may fail until the control is added.
+- Empty scorecards: the `APPROX_QUANTILES` calculated field needs
+  `duration_ms` to be a Number; check that the column shows as `#` (not
+  `Abc`) in the fields pane. If it's text, click the column → Type →
+  Number.
 
 ### Sharing
 

--- a/reference-architectures/fluent-bit/bq/setup.sh
+++ b/reference-architectures/fluent-bit/bq/setup.sh
@@ -51,5 +51,6 @@ echo
 echo "BigQuery console:"
 echo "  https://console.cloud.google.com/bigquery?project=${PROJECT_ID}&ws=!1m4!1m3!3m2!1s${PROJECT_ID}!2sspeedscale_rrpair"
 echo
-echo "Open in Data Studio (creates a new report wired to rrpair_view):"
-echo "  https://datastudio.google.com/reporting/create?c.reportId=&ds.ds0.connector=bigQuery&ds.ds0.projectId=${PROJECT_ID}&ds.ds0.type=TABLE&ds.ds0.datasetId=speedscale_rrpair&ds.ds0.tableId=rrpair_view"
+echo "Visualize with Data Studio (https://datastudio.google.com):"
+echo "  Create > Report > Blank > Add data > BigQuery >"
+echo "    ${PROJECT_ID} > speedscale_rrpair > rrpair_view"

--- a/reference-architectures/fluent-bit/bq/setup.sh
+++ b/reference-architectures/fluent-bit/bq/setup.sh
@@ -51,5 +51,5 @@ echo
 echo "BigQuery console:"
 echo "  https://console.cloud.google.com/bigquery?project=${PROJECT_ID}&ws=!1m4!1m3!3m2!1s${PROJECT_ID}!2sspeedscale_rrpair"
 echo
-echo "Open in Looker Studio (creates a new report wired to rrpair_view):"
-echo "  https://lookerstudio.google.com/reporting/create?c.reportId=&ds.ds0.connector=bigQuery&ds.ds0.projectId=${PROJECT_ID}&ds.ds0.type=TABLE&ds.ds0.datasetId=speedscale_rrpair&ds.ds0.tableId=rrpair_view"
+echo "Open in Data Studio (creates a new report wired to rrpair_view):"
+echo "  https://datastudio.google.com/reporting/create?c.reportId=&ds.ds0.connector=bigQuery&ds.ds0.projectId=${PROJECT_ID}&ds.ds0.type=TABLE&ds.ds0.datasetId=speedscale_rrpair&ds.ds0.tableId=rrpair_view"

--- a/reference-architectures/fluent-bit/bq/setup.sh
+++ b/reference-architectures/fluent-bit/bq/setup.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Set up BigQuery dataset + external table + view over the Fluent Bit GCS
+# data lake. Run once per (project, bucket) pair.
+#
+# Usage:
+#   ./setup.sh <project-id> <bucket-name>
+#
+# Example:
+#   ./setup.sh speedscale-demos speedscale-rrpair-demo
+#
+# Idempotent: re-running rebuilds the external table + view in place
+# (CREATE OR REPLACE). Safe to re-run after schema tweaks.
+
+set -euo pipefail
+
+PROJECT_ID="${1:-}"
+BUCKET="${2:-}"
+
+if [[ -z "${PROJECT_ID}" || -z "${BUCKET}" ]]; then
+  echo "Usage: $0 <project-id> <bucket-name>" >&2
+  exit 2
+fi
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "==> Creating dataset speedscale_rrpair in ${PROJECT_ID} (us-central1)..."
+bq --project_id="${PROJECT_ID}" query --use_legacy_sql=false --quiet \
+  < "${DIR}/001-dataset.sql"
+
+echo "==> Creating external table rrpair_ext over gs://${BUCKET}/..."
+# 002 references the bucket by literal name; substitute on the fly.
+sed "s|speedscale-rrpair-demo|${BUCKET}|g" "${DIR}/002-external-table.sql" \
+  | bq --project_id="${PROJECT_ID}" query --use_legacy_sql=false --quiet
+
+echo "==> Creating flattened view rrpair_view..."
+bq --project_id="${PROJECT_ID}" query --use_legacy_sql=false --quiet \
+  < "${DIR}/003-flattened-view.sql"
+
+echo
+echo "Done. Verify with:"
+echo "  bq --project_id=${PROJECT_ID} ls speedscale_rrpair"
+echo
+echo "Sample query (requires the partition filter):"
+echo "  bq --project_id=${PROJECT_ID} query --use_legacy_sql=false \\"
+echo "    'SELECT method, status_code, COUNT(*) c"
+echo "     FROM \`${PROJECT_ID}.speedscale_rrpair.rrpair_view\`"
+echo "     WHERE year=2026 AND month=5"
+echo "     GROUP BY method, status_code"
+echo "     ORDER BY c DESC'"
+echo
+echo "BigQuery console:"
+echo "  https://console.cloud.google.com/bigquery?project=${PROJECT_ID}&ws=!1m4!1m3!3m2!1s${PROJECT_ID}!2sspeedscale_rrpair"
+echo
+echo "Open in Looker Studio (creates a new report wired to rrpair_view):"
+echo "  https://lookerstudio.google.com/reporting/create?c.reportId=&ds.ds0.connector=bigQuery&ds.ds0.projectId=${PROJECT_ID}&ds.ds0.type=TABLE&ds.ds0.datasetId=speedscale_rrpair&ds.ds0.tableId=rrpair_view"


### PR DESCRIPTION
## Summary

Adds a BigQuery + Looker Studio layer on top of the byoc-fluentbit GCS data lake landed in #154. The bucket is now also a SQL query target and a Looker Studio data source — without copying any data into BigQuery storage.

```
GCS bucket  ──(external table, no copy)──>  BigQuery  ──>  Looker Studio
                                                 │
                                                 ├──  rrpair_ext   (raw, JSON columns)
                                                 └──  rrpair_view  (flat columns for BI)
```

## Cost story

- **External table = $0 BigQuery storage.** BQ reads gzipped NDJSON directly from GCS at query time.
- **Queries**: $6.25/TB scanned, **first 1 TB/month free**. At demo volumes (KB-MB) every query rounds to $0.
- **Safety belt**: `require_hive_partition_filter = TRUE` on `rrpair_ext` forces every query to include `WHERE year=… AND month=…` — without it, queries fail rather than full-scan the bucket. Protects against accidental large scans if the bucket grows.

## What's added (`reference-architectures/fluent-bit/bq/`)

| File | Purpose |
|---|---|
| `001-dataset.sql` | Creates `speedscale_rrpair` dataset in `us-central1` (matches bucket region) |
| `002-external-table.sql` | `rrpair_ext` over the Hive-partitioned bucket. Explicit schema (BQ can't autodetect — OTLP attribute keys contain dots which BQ rejects as column names). Nested objects as `JSON` columns. `ignore_unknown_values = TRUE` silently drops `@timestamp` and `__internal__`. |
| `003-flattened-view.sql` | `rrpair_view`: BI-friendly flat columns (request_time, method, status_code, host, path, duration_ms, app_label, pod_name, …) |
| `setup.sh` | `./setup.sh <project> <bucket>` — idempotent runner; prints BigQuery console + Looker Studio URLs |
| `README.md` | Cost model, partition-filter rationale, query examples, Looker Studio chart suggestions |

Top-level scenario README: mermaid diagram extended with BQ + Looker nodes downstream of the bucket, and a new 'Query + visualize' section with the Looker Studio Linking URL template.

## Verified

End-to-end against `gs://speedscale-rrpair-demo` (in `speedscale-demos` GCP project):

```bash
$ ./bq/setup.sh speedscale-demos speedscale-rrpair-demo
==> Creating dataset speedscale_rrpair in speedscale-demos (us-central1)...
==> Creating external table rrpair_ext over gs://speedscale-rrpair-demo/...
==> Creating flattened view rrpair_view...
Done.
```

Sample aggregation query returns correct results (165 RRPairs across 3 GCS objects, top endpoints `/spacex/launches` 44 hits, `/treasury/max_interest` 42 hits, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)