### PR TITLE
ci: split dependency-security into own workflow with path filters, bump jwt gem

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,119 +17,10 @@ jobs:
     - name: Validate version consistency
       run: make validate-version
 
-  # Dependency / supply-chain checks (npm, pip, Composer, Ruby, Go, .NET)
-  dependency-security:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: Set up Node
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20'
-
-    - name: npm audit (Node demos)
-      run: |
-        set -euo pipefail
-        for dir in node node-auth node-mariadb node-websocket dlp-demo smart-replace-demo llm-simulation-demo/frontend scenarios/microservices/gateway csharp/requestor; do
-          echo "::group::npm ci + audit: ${dir}"
-          (cd "$dir" && npm ci && npm audit --audit-level=moderate)
-          echo "::endgroup::"
-        done
-
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.11'
-
-    - name: pip-audit (Python requirements)
-      run: |
-        set -euo pipefail
-        python -m pip install --upgrade pip pip-audit
-        FILES=(
-          python/requirements.txt
-          xml/requirements.txt
-          llm-simulation-demo/backend/requirements.txt
-          llm-simulation-demo/tools-service/requirements.txt
-        )
-        for f in "${FILES[@]}"; do
-          echo "::group::pip-audit ${f}"
-          pip-audit -r "$f"
-          echo "::endgroup::"
-        done
-
-    - name: Set up PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: '8.3'
-        tools: composer
-
-    - name: Composer audit (PHP)
-      working-directory: php
-      run: |
-        composer install --no-interaction --no-progress --prefer-dist
-        # --abandoned=report: only fail on real security advisories. Don't
-        # fail the build just because a transitive phpunit dep is marked
-        # abandoned — matches semantics of bundle-audit / npm audit above.
-        composer audit --abandoned=report
-
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: '3.2'
-        bundler-cache: true
-        working-directory: ruby-api
-
-    - name: bundle-audit (Ruby API + client)
-      run: |
-        set -euo pipefail
-        gem install bundler-audit --no-document
-        echo "::group::ruby-api"
-        (cd ruby-api && bundle-audit check)
-        echo "::endgroup::"
-        echo "::group::ruby-api/client"
-        (cd ruby-api/client && bundle install --jobs 4 --retry 3 && bundle-audit check)
-        echo "::endgroup::"
-
-    # Pin Go to the toolchain used in go.mod (go1.26.3). setup-go@v5 + go-version-file may follow only
-    # the `go` line (1.23.x), leaving a stale preinstalled Go (e.g. 1.24) on PATH — then `go install
-    # govulncheck` builds against 1.24 and govulncheck fails loading stdlib (fips140only_go1.26.go).
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.26.3'
-
-    - name: govulncheck (Go modules)
-      env:
-        GOTOOLCHAIN: go1.26.3
-      run: |
-        set -euo pipefail
-        go version
-        go install golang.org/x/vuln/cmd/govulncheck@latest
-        export PATH="$(go env GOPATH)/bin:${PATH}"
-        for dir in go go-mongo go-postgres go-ses-demo aws/service/dynamodb/go go-rabbitmq/producer go-rabbitmq/consumer go-rabbitmq/generator; do
-          echo "::group::govulncheck ${dir}"
-          (cd "$dir" && govulncheck ./...)
-          echo "::endgroup::"
-        done
-
-    - name: Set up .NET
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: '8.0.x'
-
-    - name: dotnet list vulnerable packages
-      run: |
-        set -euo pipefail
-        (cd csharp && dotnet restore weatherService.csproj && dotnet list weatherService.csproj package --vulnerable --include-transitive)
-        (cd csharp/client && dotnet restore client.csproj && dotnet list client.csproj package --vulnerable --include-transitive)
-        (cd csharp/tests && dotnet restore WeatherServiceTests.csproj && dotnet list WeatherServiceTests.csproj package --vulnerable --include-transitive)
-
   # Unit Tests - Fast feedback on code quality
   unit-tests:
     runs-on: ubuntu-latest
-    needs: [validate, dependency-security]
+    needs: [validate]
     strategy:
       fail-fast: false
       matrix:
@@ -237,7 +128,7 @@ jobs:
   # Integration Tests - Functional correctness with proxymock
   integration-tests:
     runs-on: ubuntu-latest
-    needs: [validate, dependency-security]
+    needs: [validate]
     strategy:
       fail-fast: false
       matrix:
@@ -284,7 +175,7 @@ jobs:
   # Load Tests - Performance validation under load
   load-tests:
     runs-on: ubuntu-latest
-    needs: [validate, dependency-security]
+    needs: [validate]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/dependency-security.yml
+++ b/.github/workflows/dependency-security.yml
@@ -1,0 +1,130 @@
+name: Dependency Security
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+    paths:
+      - '**/package.json'
+      - '**/package-lock.json'
+      - '**/requirements*.txt'
+      - 'php/composer.json'
+      - 'php/composer.lock'
+      - 'ruby-api/Gemfile'
+      - 'ruby-api/Gemfile.lock'
+      - 'ruby-api/client/Gemfile'
+      - 'ruby-api/client/Gemfile.lock'
+      - '**/go.mod'
+      - '**/go.sum'
+      - '**/*.csproj'
+      - '.github/workflows/dependency-security.yml'
+
+jobs:
+  dependency-security:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Set up Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
+    - name: npm audit (Node demos)
+      run: |
+        set -euo pipefail
+        for dir in node node-auth node-mariadb node-websocket dlp-demo smart-replace-demo llm-simulation-demo/frontend scenarios/microservices/gateway csharp/requestor; do
+          echo "::group::npm ci + audit: ${dir}"
+          (cd "$dir" && npm ci && npm audit --audit-level=moderate)
+          echo "::endgroup::"
+        done
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: pip-audit (Python requirements)
+      run: |
+        set -euo pipefail
+        python -m pip install --upgrade pip pip-audit
+        FILES=(
+          python/requirements.txt
+          xml/requirements.txt
+          llm-simulation-demo/backend/requirements.txt
+          llm-simulation-demo/tools-service/requirements.txt
+        )
+        for f in "${FILES[@]}"; do
+          echo "::group::pip-audit ${f}"
+          pip-audit -r "$f"
+          echo "::endgroup::"
+        done
+
+    - name: Set up PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.3'
+        tools: composer
+
+    - name: Composer audit (PHP)
+      working-directory: php
+      run: |
+        composer install --no-interaction --no-progress --prefer-dist
+        # --abandoned=report: only fail on real security advisories. Don't
+        # fail the build just because a transitive phpunit dep is marked
+        # abandoned — matches semantics of bundle-audit / npm audit above.
+        composer audit --abandoned=report
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.2'
+        bundler-cache: true
+        working-directory: ruby-api
+
+    - name: bundle-audit (Ruby API + client)
+      run: |
+        set -euo pipefail
+        gem install bundler-audit --no-document
+        echo "::group::ruby-api"
+        (cd ruby-api && bundle-audit check)
+        echo "::endgroup::"
+        echo "::group::ruby-api/client"
+        (cd ruby-api/client && bundle install --jobs 4 --retry 3 && bundle-audit check)
+        echo "::endgroup::"
+
+    # Pin Go to the toolchain used in go.mod (go1.26.3). setup-go@v5 + go-version-file may follow only
+    # the `go` line (1.23.x), leaving a stale preinstalled Go (e.g. 1.24) on PATH — then `go install
+    # govulncheck` builds against 1.24 and govulncheck fails loading stdlib (fips140only_go1.26.go).
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.26.3'
+
+    - name: govulncheck (Go modules)
+      env:
+        GOTOOLCHAIN: go1.26.3
+      run: |
+        set -euo pipefail
+        go version
+        go install golang.org/x/vuln/cmd/govulncheck@latest
+        export PATH="$(go env GOPATH)/bin:${PATH}"
+        for dir in go go-mongo go-postgres go-ses-demo aws/service/dynamodb/go go-rabbitmq/producer go-rabbitmq/consumer go-rabbitmq/generator; do
+          echo "::group::govulncheck ${dir}"
+          (cd "$dir" && govulncheck ./...)
+          echo "::endgroup::"
+        done
+
+    - name: Set up .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '8.0.x'
+
+    - name: dotnet list vulnerable packages
+      run: |
+        set -euo pipefail
+        (cd csharp && dotnet restore weatherService.csproj && dotnet list weatherService.csproj package --vulnerable --include-transitive)
+        (cd csharp/client && dotnet restore client.csproj && dotnet list client.csproj package --vulnerable --include-transitive)
+        (cd csharp/tests && dotnet restore WeatherServiceTests.csproj && dotnet list WeatherServiceTests.csproj package --vulnerable --include-transitive)

--- a/ruby-api/Gemfile
+++ b/ruby-api/Gemfile
@@ -9,7 +9,7 @@ gem 'rackup', '~> 2.2'
 gem 'json', '2.17.1.2'
 gem 'rack', '~> 3.2', '>= 3.2.5'
 gem 'rack-session', '>= 2.1.2'
-gem 'jwt', '~> 2.7'
+gem 'jwt', '~> 2.10', '>= 2.10.3'
 
 group :test do
   gem 'rspec', '~> 3.12'

--- a/ruby-api/Gemfile.lock
+++ b/ruby-api/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
     json (2.17.1.2)
-    jwt (2.10.2)
+    jwt (2.10.3)
       base64
     logger (1.7.0)
     mini_mime (1.1.5)
@@ -75,7 +75,7 @@ PLATFORMS
 DEPENDENCIES
   httparty (~> 0.24)
   json (= 2.17.1.2)
-  jwt (~> 2.7)
+  jwt (~> 2.10, >= 2.10.3)
   pg (~> 1.5)
   puma (~> 6.4)
   rack (~> 3.2, >= 3.2.5)


### PR DESCRIPTION
## Problem

- `dependency-security` ran on every PR regardless of what changed. A PR touching only `reference-architectures/` (Kubernetes YAML) triggered the full multi-language vulnerability scan and blocked all downstream jobs.
- `jwt` gem was pinned to `~> 2.7`, resolving to `2.10.2` which has CVE-2026-45363 (High: empty-key HMAC bypass).

## Solution

- Moved `dependency-security` into its own workflow file (`dependency-security.yml`) with `paths:` filters on the `pull_request` trigger. The scan now only runs when dependency manifest files actually change.
- Simplified `needs: [validate, dependency-security]` → `needs: [validate]` in `unit-tests`, `integration-tests`, and `load-tests` so those jobs are no longer blocked by the security scan.
- Bumped `jwt` from `~> 2.7` to `~> 2.10, >= 2.10.3`; ran `bundle update jwt` to regenerate the lockfile at `2.10.3`.

## Checklist

- [x] CI workflow changes tested against intended trigger paths
- [x] Lockfile regenerated via `bundle update jwt` (not hand-edited)
- [x] No Linear ticket IDs in commit message (public repo)