### PR TITLE
feat(grafana): demo-ready BYOC traffic dashboard (1h default window)

### DIFF
--- a/reference-architectures/grafana/chart/files/speedscale-traffic.json
+++ b/reference-architectures/grafana/chart/files/speedscale-traffic.json
@@ -228,11 +228,11 @@
       }
     ]
   },
-  "time": { "from": "now-15m", "to": "now" },
+  "time": { "from": "now-1h", "to": "now" },
   "timepicker": { "refresh_intervals": ["5s", "10s", "30s", "1m"] },
   "timezone": "",
-  "title": "Speedscale Traffic",
+  "title": "Speedscale BYOC — Live API Traffic",
   "uid": "speedscale-traffic",
-  "version": 2,
+  "version": 3,
   "weekStart": ""
 }


### PR DESCRIPTION
## Problem

The hero `speedscale-traffic` dashboard defaults to a 15-minute window, so live `rate()` panels can look sparse if traffic momentarily dips during a screen-share or recording.

## Solution

- Default time `now-15m` → `now-1h` so panels stay visibly populated.
- Rename to "Speedscale BYOC — Live API Traffic" (clearer on camera).

Template variables already default to All, so no change there. Verified `helm template` renders and the dashboard JSON validates; applied + confirmed live on the demo cluster (mounted dashboard reflects the 1h window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)