### PR TITLE
Add compose override for blueprint demo

### DIFF
--- a/java-auth/docker-compose.demo.yml
+++ b/java-auth/docker-compose.demo.yml
@@ -1,0 +1,21 @@
+services:
+  mysql:
+    ports:
+      - "3307:3306"
+
+  auth-service:
+    ports:
+      - "8081:8080"
+    environment:
+      MYSQL_HOST: mysql
+      MYSQL_PORT: 3306
+      MYSQL_DATABASE: auth_db
+      MYSQL_USERNAME: auth_user
+      MYSQL_PASSWORD: secure_password
+      JWT_SECRET: your-secret-key-here-please-change-in-production
+      JWT_EXPIRATION: 10000
+      REFRESH_TOKEN_EXPIRATION: 604800000
+
+  auth-client:
+    profiles:
+      - disabled


### PR DESCRIPTION
## Summary
- Adds `java-auth/docker-compose.demo.yml` compose override for the proxymock blueprints video demo
- Sets JWT expiration to 10s so token expiry is visible on camera
- Remaps ports to 8081/3307 to avoid common conflicts with SSH tunnels
- Disables auth-client service (not needed for the demo)

Usage: `docker compose -f docker-compose.yml -f docker-compose.demo.yml up -d --build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)