### PR TITLE
Add dotnet-orders demo app (ASP.NET Core 8)

### DIFF
--- a/dotnet-orders/.dockerignore
+++ b/dotnet-orders/.dockerignore
@@ -1,0 +1,8 @@
+bin/
+obj/
+.vs/
+.vscode/
+.idea/
+TestResults/
+*.user
+.DS_Store

--- a/dotnet-orders/.gitignore
+++ b/dotnet-orders/.gitignore
@@ -1,0 +1,71 @@
+# Build results
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+x64/
+x86/
+[Ww][Ii][Nn]32/
+[Aa][Rr][Mm]/
+[Aa][Rr][Mm]64/
+bld/
+[Bb]in/
+[Oo]bj/
+[Ll]og/
+[Ll]ogs/
+
+# Visual Studio cache/options
+.vs/
+.vscode/
+
+# .NET Core
+project.lock.json
+project.fragment.lock.json
+artifacts/
+
+# User-specific files
+*.rsuser
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# Mono Auto Generated Files
+mono_crash.*
+
+# Windows image file caches
+Thumbs.db
+ehthumbs.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# JetBrains Rider
+.idea/
+*.sln.iml
+
+# Test results
+TestResults/
+[Tt]est[Rr]esult*/
+*.trx
+*.coverage
+*.coveragexml
+
+# Mac files
+.DS_Store
+
+# Environment files
+.env
+.env.local
+.env.*.local
+
+# Application logs
+logs/
+*.log
+
+# proxymock recordings/replays (demo artifacts)
+proxymock/
+.proxymock/

--- a/dotnet-orders/Dockerfile
+++ b/dotnet-orders/Dockerfile
@@ -1,0 +1,32 @@
+# Build stage
+FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build
+WORKDIR /src
+
+COPY OrdersApi.csproj .
+RUN dotnet restore
+
+COPY . .
+RUN dotnet publish -c Release -o /app/publish --no-restore
+
+# Runtime stage
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine AS runtime
+WORKDIR /app
+
+RUN addgroup -g 1000 appuser && \
+    adduser -u 1000 -G appuser -s /bin/sh -D appuser
+
+COPY --from=build /app/publish .
+
+RUN chown -R appuser:appuser /app
+
+USER appuser
+
+EXPOSE 8082
+
+ENV ASPNETCORE_URLS=http://+:8082 \
+    ASPNETCORE_ENVIRONMENT=Production
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD wget --no-verbose --tries=1 --spider http://localhost:8082/healthz || exit 1
+
+ENTRYPOINT ["dotnet", "OrdersApi.dll"]

--- a/dotnet-orders/Makefile
+++ b/dotnet-orders/Makefile
@@ -1,0 +1,56 @@
+VERSION ?= $(shell cat ../VERSION 2>/dev/null || echo "1.0.0")
+IMAGE_NAME = dotnet-orders
+REGISTRY = gcr.io/speedscale-demos
+NAMESPACE ?= default
+
+.PHONY: help build run local up down compose docker-build docker-multi test test-api health kube kube-clean clean watch format
+
+help: ## Show available commands
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
+
+build: ## Build the application
+	dotnet build -c Release
+
+local: ## Run locally
+	ASPNETCORE_URLS=http://+:8082 dotnet run
+
+run: local ## Alias for local
+
+up: ## Start with Docker Compose
+	docker compose up -d
+
+down: ## Stop containers
+	docker compose down
+
+compose: up ## Alias for up
+
+docker-build: ## Build Docker image locally
+	docker build -t $(IMAGE_NAME):$(VERSION) .
+
+docker-multi: ## Build and push multi-arch images
+	docker buildx build --push --platform linux/amd64,linux/arm64 \
+		--tag $(REGISTRY)/$(IMAGE_NAME):v$(VERSION) \
+		--tag $(REGISTRY)/$(IMAGE_NAME):latest \
+		.
+
+test-api: ## Run API test script
+	./scripts/test.sh
+
+health: ## Check health endpoint
+	curl -sf http://localhost:8082/healthz | jq .
+
+kube: ## Deploy to Kubernetes
+	kubectl -n $(NAMESPACE) apply -f k8s/base/
+
+kube-clean: ## Remove from Kubernetes
+	kubectl -n $(NAMESPACE) delete -f k8s/base/
+
+clean: ## Clean build artifacts
+	dotnet clean
+	rm -rf bin/ obj/
+
+watch: ## Run with hot reload
+	ASPNETCORE_URLS=http://+:8082 dotnet watch run
+
+format: ## Format code
+	dotnet format

--- a/dotnet-orders/OrdersApi.csproj
+++ b/dotnet-orders/OrdersApi.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>OrdersApi</RootNamespace>
+    <AssemblyName>OrdersApi</AssemblyName>
+  </PropertyGroup>
+
+</Project>

--- a/dotnet-orders/Program.cs
+++ b/dotnet-orders/Program.cs
@@ -1,0 +1,56 @@
+using System.Collections.Concurrent;
+
+var builder = WebApplication.CreateBuilder(args);
+
+var app = builder.Build();
+
+// In-memory order store: orderId -> status
+var orders = new ConcurrentDictionary<string, string>();
+
+// Health check
+app.MapGet("/healthz", () => Results.Ok(new { status = "ok" }));
+
+// List orders
+app.MapGet("/orders", () =>
+{
+    var list = orders.Select(kvp => new { orderId = kvp.Key, status = kvp.Value }).ToList();
+    return Results.Ok(list);
+});
+
+// Create order — generates a new UUID v4 order id
+app.MapPost("/orders", (CreateOrderRequest? req) =>
+{
+    var orderId = Guid.NewGuid().ToString();
+    orders[orderId] = "created";
+    return Results.Created($"/orders/{orderId}", new
+    {
+        orderId,
+        status = "created",
+        item = req?.Item ?? "unknown",
+        quantity = req?.Quantity ?? 1,
+        createdAt = DateTime.UtcNow.ToString("O")
+    });
+});
+
+// Confirm order — accepts the same orderId in the request body
+app.MapPost("/orders/confirm", (ConfirmOrderRequest req) =>
+{
+    if (string.IsNullOrWhiteSpace(req.OrderId))
+        return Results.BadRequest(new { error = "orderId is required" });
+
+    if (!orders.ContainsKey(req.OrderId))
+        return Results.NotFound(new { error = "order not found", orderId = req.OrderId });
+
+    orders[req.OrderId] = "confirmed";
+    return Results.Ok(new
+    {
+        orderId = req.OrderId,
+        status = "confirmed",
+        confirmedAt = DateTime.UtcNow.ToString("O")
+    });
+});
+
+app.Run();
+
+record CreateOrderRequest(string? Item, int? Quantity);
+record ConfirmOrderRequest(string OrderId);

--- a/dotnet-orders/README.md
+++ b/dotnet-orders/README.md
@@ -1,0 +1,106 @@
+# .NET Orders Service
+
+An ASP.NET Core 8 minimal-API service that demonstrates a simple order create-and-confirm flow. It is designed to showcase Speedscale proxymock's `smart_replace_recorded` transform: when you record the `POST /orders` → `POST /orders/confirm` flow, proxymock detects that the UUID order id returned by the first call is reused in the second call's request body, and automatically recommends a transform.
+
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/healthz` | Health check |
+| `GET` | `/orders` | List all orders |
+| `POST` | `/orders` | Create an order; returns a new UUID v4 `orderId` |
+| `POST` | `/orders/confirm` | Confirm an order by `orderId` in the request body |
+
+### POST /orders
+
+Request (all fields optional):
+```json
+{ "item": "widget", "quantity": 2 }
+```
+
+Response `201 Created`:
+```json
+{
+  "orderId": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "created",
+  "item": "widget",
+  "quantity": 2,
+  "createdAt": "2024-01-01T12:00:00.000Z"
+}
+```
+
+### POST /orders/confirm
+
+Request:
+```json
+{ "orderId": "550e8400-e29b-41d4-a716-446655440000" }
+```
+
+Response `200 OK`:
+```json
+{
+  "orderId": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "confirmed",
+  "confirmedAt": "2024-01-01T12:00:05.000Z"
+}
+```
+
+## Quick Start
+
+### Docker Compose
+
+```bash
+docker compose up -d
+```
+
+Service is available at `http://localhost:8082`.
+
+### Run Locally
+
+Requires .NET 8 SDK.
+
+```bash
+make local
+```
+
+### Make Targets
+
+```bash
+make help          # list all targets
+make build         # dotnet build
+make local         # run locally on port 8082
+make up            # docker compose up -d
+make down          # docker compose down
+make docker-build  # build Docker image
+make test-api      # run scripts/test.sh
+make health        # curl /healthz
+make kube          # kubectl apply k8s/base/
+make kube-clean    # kubectl delete k8s/base/
+```
+
+## Demo Flow
+
+Run `scripts/test.sh` to exercise the full create→confirm flow:
+
+```bash
+./scripts/test.sh                   # defaults to localhost:8082
+./scripts/test.sh localhost:8082    # explicit host
+```
+
+The script:
+1. `POST /orders` — captures the `orderId` from the response
+2. `POST /orders/confirm` — sends that same `orderId` in the request body
+3. `GET /orders` — lists all orders
+
+When recorded with `proxymock record`, the UUID round-trip triggers a `smart_replace_recorded` recommendation in `proxymock web`.
+
+## Storage
+
+Orders are kept in memory only. The store is reset when the process restarts — no database required.
+
+## Configuration
+
+| Env var | Default | Description |
+|---------|---------|-------------|
+| `ASPNETCORE_URLS` | `http://+:8082` | Listen address |
+| `ASPNETCORE_ENVIRONMENT` | `Production` | Runtime environment |

--- a/dotnet-orders/appsettings.json
+++ b/dotnet-orders/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/dotnet-orders/docker-compose.yml
+++ b/dotnet-orders/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  dotnet-orders:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: dotnet-orders
+    restart: always
+    ports:
+      - "8082:8082"
+    environment:
+      ASPNETCORE_URLS: http://+:8082
+      ASPNETCORE_ENVIRONMENT: Production
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8082/healthz"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 10s

--- a/dotnet-orders/k8s/base/deployment.yaml
+++ b/dotnet-orders/k8s/base/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dotnet-orders
+  labels:
+    app: dotnet-orders
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dotnet-orders
+  template:
+    metadata:
+      labels:
+        app: dotnet-orders
+        version: v1
+    spec:
+      containers:
+      - name: dotnet-orders
+        image: gcr.io/speedscale-demos/dotnet-orders:latest
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8082
+          name: http
+          protocol: TCP
+        env:
+        - name: ASPNETCORE_URLS
+          value: "http://+:8082"
+        - name: ASPNETCORE_ENVIRONMENT
+          value: "Production"
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "50m"
+          limits:
+            memory: "256Mi"
+            cpu: "500m"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8082
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8082
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+          successThreshold: 1
+          failureThreshold: 3
+        lifecycle:
+          preStop:
+            exec:
+              command: ["sh", "-c", "sleep 5"]
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30

--- a/dotnet-orders/k8s/base/kustomization.yaml
+++ b/dotnet-orders/k8s/base/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml
+
+labels:
+  - pairs:
+      app.kubernetes.io/name: dotnet-orders
+      app.kubernetes.io/instance: dotnet-orders
+      app.kubernetes.io/part-of: dotnet-orders-system
+      app.kubernetes.io/managed-by: kustomize
+    includeSelectors: true

--- a/dotnet-orders/k8s/base/service.yaml
+++ b/dotnet-orders/k8s/base/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dotnet-orders-service
+  labels:
+    app: dotnet-orders
+spec:
+  selector:
+    app: dotnet-orders
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8082
+    protocol: TCP
+  type: ClusterIP
+  sessionAffinity: None

--- a/dotnet-orders/scripts/test.sh
+++ b/dotnet-orders/scripts/test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+HOST="${1:-localhost:8082}"
+
+echo "==> POST /orders (create)"
+RESPONSE=$(curl -sf -X POST "http://${HOST}/orders" \
+  -H "Content-Type: application/json" \
+  -d '{"item":"widget","quantity":2}')
+echo "${RESPONSE}" | jq .
+ORDER_ID=$(echo "${RESPONSE}" | jq -r '.orderId')
+echo "  orderId: ${ORDER_ID}"
+
+echo ""
+echo "==> POST /orders/confirm (confirm with same orderId)"
+curl -sf -X POST "http://${HOST}/orders/confirm" \
+  -H "Content-Type: application/json" \
+  -d "{\"orderId\":\"${ORDER_ID}\"}" | jq .
+
+echo ""
+echo "==> GET /orders (list)"
+curl -sf "http://${HOST}/orders" | jq .


### PR DESCRIPTION
## Summary

- New `dotnet-orders/` demo: ASP.NET Core 8 minimal-API service with `POST /orders` (returns a UUID v4 `orderId`) and `POST /orders/confirm` (accepts that same `orderId` in the JSON request body)
- Designed to trigger proxymock's `smart_replace_recorded` recommendation when the create→confirm flow is recorded
- In-memory store — no database dependency; single port 8082 throughout (compose, Dockerfile EXPOSE, healthcheck)
- Mirrors java-auth's project layout: Dockerfile (multi-stage), docker-compose.yml, k8s/ manifests (deployment + service + kustomization), Makefile, README.md, scripts/test.sh

## Test plan

- [ ] `make build` — `dotnet build -c Release` succeeds
- [ ] `make local` — service starts on port 8082
- [ ] `./scripts/test.sh` — POST /orders returns a UUID orderId; POST /orders/confirm echoes the same orderId with status "confirmed"
- [ ] `make up` / `make down` — docker compose round-trip works
- [ ] `make kube` — manifests apply cleanly against a cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)