### PR TITLE
Add trace-demo scenario for distributed-trace capture

### DIFF
--- a/scenarios/trace-demo/.gitignore
+++ b/scenarios/trace-demo/.gitignore
@@ -1,0 +1,2 @@
+bin/
+app/trace-demo

--- a/scenarios/trace-demo/Dockerfile
+++ b/scenarios/trace-demo/Dockerfile
@@ -1,0 +1,13 @@
+# Single image, multi-role: ROLE selects gateway | cart | pricing | tax |
+# payment | shipping | loadgen at runtime (see k8s manifests).
+FROM golang:1.23-alpine AS build
+WORKDIR /src
+COPY app/go.mod ./
+RUN go mod download
+COPY app/ ./
+RUN CGO_ENABLED=0 go build -trimpath -o /trace-demo .
+
+FROM gcr.io/distroless/static-debian12
+COPY --from=build /trace-demo /trace-demo
+EXPOSE 8080
+ENTRYPOINT ["/trace-demo"]

--- a/scenarios/trace-demo/Makefile
+++ b/scenarios/trace-demo/Makefile
@@ -1,0 +1,30 @@
+IMAGE ?= trace-demo:local
+
+.PHONY: help test build image deploy minikube undeploy run-local
+
+help:
+	@echo "trace-demo targets:"
+	@echo "  make test      - go vet + unit tests for the app"
+	@echo "  make build     - compile the app binary"
+	@echo "  make image     - docker build $(IMAGE)"
+	@echo "  make minikube  - build into minikube's docker + deploy the stack"
+	@echo "  make deploy    - kubectl apply -k k8s (image must already exist)"
+	@echo "  make undeploy  - delete the trace-demo namespace"
+
+test:
+	cd app && go vet ./... && go test ./...
+
+build:
+	cd app && CGO_ENABLED=0 go build -o ../bin/trace-demo .
+
+image:
+	docker build -t $(IMAGE) .
+
+minikube:
+	./k8s/deploy-minikube.sh
+
+deploy:
+	kubectl apply -k k8s
+
+undeploy:
+	kubectl delete namespace trace-demo --ignore-not-found

--- a/scenarios/trace-demo/README.md
+++ b/scenarios/trace-demo/README.md
@@ -62,20 +62,44 @@ Tip: because the waterfall is driven by the *filtered* grid, adding a
 `Direction = IN` (or `OUT`) filter alongside `X-Trace-Id` shows just the
 server-side (or client-side) half of each hop.
 
-## Run locally (no Kubernetes)
+## Record locally with `proxymock record` (no Kubernetes)
 
-Each role is just an env var, so you can run the stack on your laptop and record
-it with the proxymock CLI:
+`proxymock record` runs two smart proxies around your app — an **inbound** proxy
+on `:4143` (in front of the app) and an **outbound** proxy on `:4140` (behind
+it). Requests through either are recorded. We record the gateway: its inbound
+`/checkout` plus its fan-out to the backends (and `pricing → tax`).
+
+There's a one-command helper:
 
 ```bash
-cd app
-ROLE=tax      PORT=8085 go run . &
-ROLE=cart     PORT=8081 go run . &
-ROLE=shipping PORT=8084 go run . &
-ROLE=payment  PORT=8083 go run . &
-ROLE=pricing  PORT=8082 TAX_URL=http://localhost:8085 go run . &
-ROLE=gateway  PORT=8080 \
-  CART_URL=http://localhost:8081 PRICING_URL=http://localhost:8082 \
-  PAYMENT_URL=http://localhost:8083 SHIPPING_URL=http://localhost:8084 go run . &
-ROLE=loadgen  GATEWAY_URL=http://localhost:8080 COUNT=150 LOOP=false go run .
+cd scenarios/trace-demo
+./record-local.sh            # terminal 1: starts backends + records the gateway
 ```
+
+Then drive traffic and view it:
+
+```bash
+# terminal 2: at least 100 distinct traces through the inbound proxy (:4143)
+ROLE=loadgen GATEWAY_URL=http://localhost:4143 COUNT=150 LOOP=false /tmp/trace-demo
+
+proxymock web                # browse the capture; filter X-Trace-Id, click Trace
+```
+
+Ctrl-C the recorder in terminal 1 when you're done; it stops the backends too.
+
+### Why the downstream URLs use `$(hostname)`, not `localhost`
+
+`proxymock record` captures the gateway's **outbound** calls only when they go
+through its outbound proxy — and Go's HTTP client (via `http_proxy`/`https_proxy`)
+**bypasses the proxy for `localhost` and loopback addresses**. So the helper
+points the gateway (and pricing → tax) at `http://$(hostname):<port>` instead,
+which Go routes through proxymock's `:4140` proxy and records. Inbound is
+unaffected — drive it at `localhost:4143`.
+
+### Doing it by hand
+
+If you'd rather not use the script, the equivalent is: start `cart`, `tax`,
+`payment`, `shipping` on their ports; start `pricing` with
+`http_proxy=https_proxy=http://localhost:4140` and `TAX_URL=http://$(hostname):8085`;
+then `proxymock record --app-port 8080 -- env ROLE=gateway PORT=8080 CART_URL=http://$(hostname):8081 … /tmp/trace-demo`.
+See `record-local.sh` for the exact commands.

--- a/scenarios/trace-demo/README.md
+++ b/scenarios/trace-demo/README.md
@@ -1,0 +1,81 @@
+# trace-demo
+
+A small distributed "checkout" stack that emits **real distributed traces** when
+recorded with Speedscale/proxymock. It exists to generate test data for the
+proxymock-web **Trace** waterfall: deploy it, record, then filter the Requests
+grid by one `X-Trace-Id` and watch the view reconstruct that request's full
+journey across services.
+
+## Topology
+
+One `/checkout` request fans out across six services and two levels of depth:
+
+```
+loadgen ─▶ gateway ─┬─▶ cart      (GET  /cart/validate)
+                    ├─▶ pricing   (POST /price) ─▶ tax (GET /tax/calculate)
+                    ├─▶ payment   (POST /charge)        ← fails ~12% (error spans)
+                    └─▶ shipping  (POST /ship)
+```
+
+Every hop propagates W3C `traceparent`, Zipkin **B3** (`X-B3-TraceId/SpanId/ParentSpanId`),
+and a stable **`X-Trace-Id`** that is constant across all hops of one request.
+`X-Trace-Id` is your grouping key (filter on it); the B3 span ids give the
+waterfall its exact parent/child nesting.
+
+It's all one Go binary; `ROLE` selects which service (or the `loadgen` client)
+it runs as — so the whole stack is a single image.
+
+## At least 100 traces
+
+`loadgen` drives `COUNT` (default **150**) distinct traces per pass — each a
+fresh root trace id — then loops (`LOOP=true`) so any recording window keeps
+seeing traffic. 150 traces take ~25s at the default 150 ms spacing.
+
+## Deploy to minikube
+
+Builds the image straight into minikube's Docker (no registry needed):
+
+```bash
+cd scenarios/trace-demo
+make minikube          # or: ./k8s/deploy-minikube.sh
+```
+
+This brings up `gateway`, `cart`, `pricing`, `tax`, `payment`, `shipping`, and
+`loadgen` in the `trace-demo` namespace. Both the **client** (`loadgen`) and the
+**servers** are deployed and annotated `capture.speedscale.com/enabled: "true"`,
+so both sides of every call are recorded.
+
+Tear down with `make undeploy`.
+
+## Record and view
+
+1. Record the `trace-demo` namespace with Speedscale (operator capture) or
+   proxymock.
+2. In proxymock-web → **Requests**, open **Filters** and add a **Request Header**
+   filter on `X-Trace-Id` set to any one captured value (the grid shows them).
+3. Click the **Trace** toggle. You'll see that request's waterfall — gateway at
+   the root, its downstream calls nested beneath, `pricing → tax` one level
+   deeper, and a red bar on any trace whose payment failed. Click any bar to open
+   its RRPair detail.
+
+Tip: because the waterfall is driven by the *filtered* grid, adding a
+`Direction = IN` (or `OUT`) filter alongside `X-Trace-Id` shows just the
+server-side (or client-side) half of each hop.
+
+## Run locally (no Kubernetes)
+
+Each role is just an env var, so you can run the stack on your laptop and record
+it with the proxymock CLI:
+
+```bash
+cd app
+ROLE=tax      PORT=8085 go run . &
+ROLE=cart     PORT=8081 go run . &
+ROLE=shipping PORT=8084 go run . &
+ROLE=payment  PORT=8083 go run . &
+ROLE=pricing  PORT=8082 TAX_URL=http://localhost:8085 go run . &
+ROLE=gateway  PORT=8080 \
+  CART_URL=http://localhost:8081 PRICING_URL=http://localhost:8082 \
+  PAYMENT_URL=http://localhost:8083 SHIPPING_URL=http://localhost:8084 go run . &
+ROLE=loadgen  GATEWAY_URL=http://localhost:8080 COUNT=150 LOOP=false go run .
+```

--- a/scenarios/trace-demo/app/go.mod
+++ b/scenarios/trace-demo/app/go.mod
@@ -1,0 +1,3 @@
+module trace-demo
+
+go 1.23

--- a/scenarios/trace-demo/app/main.go
+++ b/scenarios/trace-demo/app/main.go
@@ -216,7 +216,7 @@ func runLoadgen() {
 		}
 		if !loop {
 			log.Printf("done: %d traces sent (%d failed)", sent, errs)
-			select {} // idle so the pod (and its recorded data) stays up
+			return // one-shot batch (used by local recording); exit cleanly
 		}
 	}
 }

--- a/scenarios/trace-demo/app/main.go
+++ b/scenarios/trace-demo/app/main.go
@@ -1,0 +1,322 @@
+// trace-demo is a single binary that plays one of several roles in a small
+// distributed "checkout" call graph. Run as different roles (set ROLE) it
+// becomes the client (loadgen) or one of the services (gateway, cart, pricing,
+// tax, payment, shipping).
+//
+// Every request carries W3C `traceparent`, Zipkin B3 (`X-B3-*`), and a stable
+// `X-Trace-Id` that is constant across all hops of one logical request. Each
+// service mints a fresh child span id for every downstream call and propagates
+// the parent linkage, so a Speedscale/proxymock recording of this stack yields
+// real distributed traces: filter the Requests grid by one `X-Trace-Id` value
+// and the proxymock-web Trace waterfall reconstructs that request's full
+// journey (gateway → cart / pricing → tax / payment / shipping).
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log"
+	"math/rand"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// httpClient is shared by every downstream call; the short timeout keeps a slow
+// or failing dependency from stalling a whole trace.
+var httpClient = &http.Client{Timeout: 5 * time.Second}
+
+func main() {
+	role := strings.ToLower(env("ROLE", "gateway"))
+	log.SetFlags(log.LstdFlags | log.Lmsgprefix)
+	log.SetPrefix("[" + role + "] ")
+
+	if role == "loadgen" {
+		runLoadgen()
+		return
+	}
+	runServer(role)
+}
+
+// ─── trace context ───────────────────────────────────────────────────────────
+
+// traceCtx is the propagation state for one in-flight request: the stable trace
+// id shared by every hop, and the span id of the current hop (which becomes the
+// parent span id of any downstream call this hop makes).
+type traceCtx struct {
+	traceID string
+	spanID  string
+}
+
+// incoming reconstructs the trace context from an inbound request's headers,
+// minting fresh ids when a header is absent (e.g. a request that entered without
+// trace context). It reads X-Trace-Id first, then B3, then traceparent.
+func incoming(r *http.Request) traceCtx {
+	tid := firstNonEmpty(
+		r.Header.Get("X-Trace-Id"),
+		r.Header.Get("X-B3-TraceId"),
+		traceparentField(r.Header.Get("traceparent"), 1),
+	)
+	if tid == "" {
+		tid = genID(16)
+	}
+	sid := firstNonEmpty(
+		r.Header.Get("X-B3-SpanId"),
+		traceparentField(r.Header.Get("traceparent"), 2),
+	)
+	if sid == "" {
+		sid = genID(8)
+	}
+	return traceCtx{traceID: tid, spanID: sid}
+}
+
+// childHeaders returns the propagation headers for a downstream call: the trace
+// id stays constant, `child` is the new span, and the current hop's span becomes
+// the parent. Pure (no I/O) so it can be unit-tested.
+func childHeaders(tc traceCtx, child string) map[string]string {
+	return map[string]string{
+		"X-Trace-Id":        tc.traceID,
+		"X-Request-Id":      tc.traceID,
+		"traceparent":       "00-" + tc.traceID + "-" + child + "-01",
+		"X-B3-TraceId":      tc.traceID,
+		"X-B3-SpanId":       child,
+		"X-B3-ParentSpanId": tc.spanID,
+	}
+}
+
+// call makes a downstream request as a child span of tc and returns the status
+// code. Body bytes are drained so connections are reused across a trace.
+func call(ctx context.Context, tc traceCtx, method, url string, body []byte) (int, error) {
+	var rdr io.Reader
+	if body != nil {
+		rdr = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, url, rdr)
+	if err != nil {
+		return 0, err
+	}
+	for k, v := range childHeaders(tc, genID(8)) {
+		req.Header.Set(k, v)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return resp.StatusCode, nil
+}
+
+// ─── servers ─────────────────────────────────────────────────────────────────
+
+func runServer(role string) {
+	mux := http.NewServeMux()
+	// Liveness/readiness; never instrumented as a trace hop.
+	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) { io.WriteString(w, "ok") })
+
+	switch role {
+	case "gateway":
+		mux.HandleFunc("/checkout", gatewayCheckout)
+	case "cart":
+		mux.HandleFunc("/cart/validate", leaf(15, 40, 0))
+	case "pricing":
+		mux.HandleFunc("/price", pricingPrice)
+	case "tax":
+		mux.HandleFunc("/tax/calculate", leaf(10, 30, 0))
+	case "payment":
+		// Payment fails ~12% of the time so the waterfall has error spans.
+		mux.HandleFunc("/charge", leaf(30, 90, 12))
+	case "shipping":
+		mux.HandleFunc("/ship", leaf(10, 25, 0))
+	default:
+		log.Fatalf("unknown ROLE %q (want gateway|cart|pricing|tax|payment|shipping|loadgen)", role)
+	}
+
+	addr := ":" + env("PORT", "8080")
+	log.Printf("listening on %s", addr)
+	log.Fatal(http.ListenAndServe(addr, mux))
+}
+
+// gatewayCheckout is the trace root on the server side: it fans out to the
+// downstream services, each as a child span, and fails the checkout if payment
+// declines so an error propagates up the trace.
+func gatewayCheckout(w http.ResponseWriter, r *http.Request) {
+	tc := incoming(r)
+	ctx := r.Context()
+	work(8, 18)
+
+	_, _ = call(ctx, tc, http.MethodGet, urlFor("CART_URL", "http://cart")+"/cart/validate", nil)
+	_, _ = call(ctx, tc, http.MethodPost, urlFor("PRICING_URL", "http://pricing")+"/price", []byte(`{"sku":"DONUT-001","qty":3}`))
+
+	payStatus, _ := call(ctx, tc, http.MethodPost, urlFor("PAYMENT_URL", "http://payment")+"/charge", []byte(`{"amount":1299}`))
+	if payStatus >= 500 || payStatus == http.StatusPaymentRequired {
+		writeJSON(w, http.StatusBadGateway, map[string]any{"ok": false, "stage": "payment", "trace": tc.traceID})
+		return
+	}
+
+	_, _ = call(ctx, tc, http.MethodPost, urlFor("SHIPPING_URL", "http://shipping")+"/ship", []byte(`{"addr":"1 Main St"}`))
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "trace": tc.traceID})
+}
+
+// pricingPrice adds the one second-level hop in the graph (pricing → tax), so
+// the trace has depth beyond the gateway's direct children.
+func pricingPrice(w http.ResponseWriter, r *http.Request) {
+	tc := incoming(r)
+	work(12, 30)
+	_, _ = call(r.Context(), tc, http.MethodGet, urlFor("TAX_URL", "http://tax")+"/tax/calculate", nil)
+	writeJSON(w, http.StatusOK, map[string]any{"price": 1299, "currency": "USD"})
+}
+
+// leaf returns a handler that simulates processing latency and, with failPct
+// probability, returns a 500 — used for the services at the edge of the graph.
+func leaf(minMs, maxMs, failPct int) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		work(minMs, maxMs)
+		if failPct > 0 && rand.Intn(100) < failPct {
+			writeJSON(w, http.StatusInternalServerError, map[string]any{"ok": false})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+	}
+}
+
+// ─── loadgen (client) ────────────────────────────────────────────────────────
+
+// runLoadgen is the client role: it drives at least COUNT distinct traces
+// through the gateway (each with a fresh root trace + span id), then keeps
+// looping when LOOP=true so a recording window of any length captures traffic.
+func runLoadgen() {
+	gateway := urlFor("GATEWAY_URL", "http://gateway")
+	count := envInt("COUNT", 150)
+	delay := time.Duration(envInt("DELAY_MS", 150)) * time.Millisecond
+	loop := strings.ToLower(env("LOOP", "true")) == "true"
+
+	// Give the services time to come up before the first request.
+	waitReady(gateway + "/health")
+	log.Printf("driving %d traces at %s (delay=%s, loop=%t)", count, gateway, delay, loop)
+
+	sent, errs := 0, 0
+	for {
+		for i := 0; i < count; i++ {
+			if err := oneCheckout(gateway); err != nil {
+				errs++
+			}
+			sent++
+			if sent%25 == 0 {
+				log.Printf("sent %d traces (%d errors)", sent, errs)
+			}
+			time.Sleep(delay)
+		}
+		if !loop {
+			log.Printf("done: %d traces sent (%d failed)", sent, errs)
+			select {} // idle so the pod (and its recorded data) stays up
+		}
+	}
+}
+
+// oneCheckout sends a single /checkout as a brand-new trace root.
+func oneCheckout(gateway string) error {
+	tc := traceCtx{traceID: genID(16), spanID: genID(8)}
+	body, _ := json.Marshal(map[string]any{"cart": []string{"DONUT-001", "COFFEE-002"}})
+	req, err := http.NewRequest(http.MethodPost, gateway+"/checkout", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	// The root has no parent span; everything downstream descends from this.
+	for k, v := range childHeaders(tc, tc.spanID) {
+		req.Header.Set(k, v)
+	}
+	req.Header.Del("X-B3-ParentSpanId")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return nil
+}
+
+func waitReady(healthURL string) {
+	for i := 0; i < 60; i++ {
+		if resp, err := httpClient.Get(healthURL); err == nil {
+			resp.Body.Close()
+			return
+		}
+		time.Sleep(2 * time.Second)
+	}
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+// work blocks for a random duration in [minMs, maxMs] so recorded spans have
+// realistic, varied widths in the waterfall.
+func work(minMs, maxMs int) {
+	d := minMs
+	if maxMs > minMs {
+		d += rand.Intn(maxMs - minMs)
+	}
+	time.Sleep(time.Duration(d) * time.Millisecond)
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// traceparentField returns the i-th dash-separated field of a W3C traceparent
+// (1 = trace id, 2 = span id), or "" if absent/malformed.
+func traceparentField(tp string, i int) string {
+	if tp == "" {
+		return ""
+	}
+	parts := strings.Split(tp, "-")
+	if len(parts) <= i {
+		return ""
+	}
+	return strings.ToLower(parts[i])
+}
+
+func genID(nBytes int) string {
+	const hexdigits = "0123456789abcdef"
+	b := make([]byte, nBytes*2)
+	for i := range b {
+		b[i] = hexdigits[rand.Intn(16)]
+	}
+	return string(b)
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func urlFor(envKey, def string) string { return strings.TrimRight(env(envKey, def), "/") }
+
+func env(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func envInt(key string, def int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return def
+}

--- a/scenarios/trace-demo/app/main_test.go
+++ b/scenarios/trace-demo/app/main_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestChildHeaders_PropagatesTraceAndParent(t *testing.T) {
+	tc := traceCtx{traceID: "0af7651916cd43dd8448eb211c80319c", spanID: "b7ad6b7169203331"}
+	h := childHeaders(tc, "00f067aa0ba902b7")
+
+	if h["X-Trace-Id"] != tc.traceID {
+		t.Errorf("X-Trace-Id = %q, want stable trace id %q", h["X-Trace-Id"], tc.traceID)
+	}
+	if h["X-B3-ParentSpanId"] != tc.spanID {
+		t.Errorf("parent span = %q, want current span %q", h["X-B3-ParentSpanId"], tc.spanID)
+	}
+	if h["X-B3-SpanId"] != "00f067aa0ba902b7" {
+		t.Errorf("child span = %q, want new child", h["X-B3-SpanId"])
+	}
+	if want := "00-" + tc.traceID + "-00f067aa0ba902b7-01"; h["traceparent"] != want {
+		t.Errorf("traceparent = %q, want %q", h["traceparent"], want)
+	}
+}
+
+func TestIncoming_RoundTripsB3(t *testing.T) {
+	// A child's headers, read back by the next service, must yield that child's
+	// span as the new "current" span (so its downstreams parent onto it).
+	parent := traceCtx{traceID: "abc123", spanID: "1111111111111111"}
+	h := childHeaders(parent, "2222222222222222")
+
+	r := httptest.NewRequest("GET", "/", nil)
+	for k, v := range h {
+		r.Header.Set(k, v)
+	}
+	got := incoming(r)
+
+	if got.traceID != "abc123" {
+		t.Errorf("traceID = %q, want abc123", got.traceID)
+	}
+	if got.spanID != "2222222222222222" {
+		t.Errorf("spanID = %q, want the child span 2222222222222222", got.spanID)
+	}
+}
+
+func TestIncoming_MintsWhenAbsent(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	got := incoming(r)
+	if len(got.traceID) != 32 || len(got.spanID) != 16 {
+		t.Errorf("minted ids wrong length: trace=%d span=%d", len(got.traceID), len(got.spanID))
+	}
+}
+
+func TestTraceparentField(t *testing.T) {
+	tp := "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+	if got := traceparentField(tp, 1); got != "0af7651916cd43dd8448eb211c80319c" {
+		t.Errorf("trace id field = %q", got)
+	}
+	if got := traceparentField(tp, 2); got != "b7ad6b7169203331" {
+		t.Errorf("span id field = %q", got)
+	}
+	if got := traceparentField("", 1); got != "" {
+		t.Errorf("empty traceparent should yield empty, got %q", got)
+	}
+}

--- a/scenarios/trace-demo/k8s/backends.yaml
+++ b/scenarios/trace-demo/k8s/backends.yaml
@@ -1,0 +1,245 @@
+# Backend services behind the gateway. Each is the same image in a different
+# ROLE. pricing makes the one second-level call (pricing → tax), giving the
+# trace depth beyond the gateway's direct children. All are capture-enabled so a
+# recording sees every hop of every trace.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cart
+  namespace: trace-demo
+  annotations:
+    capture.speedscale.com/enabled: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cart
+  template:
+    metadata:
+      labels:
+        app: cart
+    spec:
+      containers:
+        - name: cart
+          image: trace-demo:local
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: ROLE
+              value: "cart"
+          ports:
+            - containerPort: 8080
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          resources:
+            requests: { cpu: 10m, memory: 24Mi }
+            limits: { cpu: 100m, memory: 64Mi }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cart
+  namespace: trace-demo
+spec:
+  ports:
+    - { name: http, port: 80, targetPort: 8080 }
+  selector:
+    app: cart
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pricing
+  namespace: trace-demo
+  annotations:
+    capture.speedscale.com/enabled: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pricing
+  template:
+    metadata:
+      labels:
+        app: pricing
+    spec:
+      containers:
+        - name: pricing
+          image: trace-demo:local
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: ROLE
+              value: "pricing"
+            - name: TAX_URL
+              value: "http://tax"
+          ports:
+            - containerPort: 8080
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          resources:
+            requests: { cpu: 10m, memory: 24Mi }
+            limits: { cpu: 100m, memory: 64Mi }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pricing
+  namespace: trace-demo
+spec:
+  ports:
+    - { name: http, port: 80, targetPort: 8080 }
+  selector:
+    app: pricing
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tax
+  namespace: trace-demo
+  annotations:
+    capture.speedscale.com/enabled: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tax
+  template:
+    metadata:
+      labels:
+        app: tax
+    spec:
+      containers:
+        - name: tax
+          image: trace-demo:local
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: ROLE
+              value: "tax"
+          ports:
+            - containerPort: 8080
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          resources:
+            requests: { cpu: 10m, memory: 24Mi }
+            limits: { cpu: 100m, memory: 64Mi }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tax
+  namespace: trace-demo
+spec:
+  ports:
+    - { name: http, port: 80, targetPort: 8080 }
+  selector:
+    app: tax
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payment
+  namespace: trace-demo
+  annotations:
+    capture.speedscale.com/enabled: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: payment
+  template:
+    metadata:
+      labels:
+        app: payment
+    spec:
+      containers:
+        - name: payment
+          image: trace-demo:local
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: ROLE
+              value: "payment"
+          ports:
+            - containerPort: 8080
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          resources:
+            requests: { cpu: 10m, memory: 24Mi }
+            limits: { cpu: 100m, memory: 64Mi }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: payment
+  namespace: trace-demo
+spec:
+  ports:
+    - { name: http, port: 80, targetPort: 8080 }
+  selector:
+    app: payment
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: shipping
+  namespace: trace-demo
+  annotations:
+    capture.speedscale.com/enabled: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: shipping
+  template:
+    metadata:
+      labels:
+        app: shipping
+    spec:
+      containers:
+        - name: shipping
+          image: trace-demo:local
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: ROLE
+              value: "shipping"
+          ports:
+            - containerPort: 8080
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          resources:
+            requests: { cpu: 10m, memory: 24Mi }
+            limits: { cpu: 100m, memory: 64Mi }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: shipping
+  namespace: trace-demo
+spec:
+  ports:
+    - { name: http, port: 80, targetPort: 8080 }
+  selector:
+    app: shipping

--- a/scenarios/trace-demo/k8s/deploy-minikube.sh
+++ b/scenarios/trace-demo/k8s/deploy-minikube.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Build the trace-demo image inside minikube's Docker and deploy the whole
+# stack (gateway + 5 backends + loadgen) to the trace-demo namespace.
+# Run from anywhere; paths resolve relative to this script.
+set -euo pipefail
+
+SCENARIO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+echo "Pointing Docker at minikube..."
+eval "$(minikube docker-env)"
+
+echo "Building trace-demo:local..."
+docker build -t trace-demo:local "$SCENARIO_DIR"
+
+echo "Deploying to namespace trace-demo..."
+kubectl apply -k "$SCENARIO_DIR/k8s"
+
+echo "Waiting for rollouts..."
+for d in cart pricing tax payment shipping gateway loadgen; do
+  kubectl rollout status "deployment/$d" -n trace-demo --timeout=120s
+done
+
+cat <<'EOF'
+
+Stack is up in namespace "trace-demo". The loadgen is already driving traces.
+
+Smoke-test the gateway directly:
+  kubectl port-forward -n trace-demo svc/gateway 8080:80
+  curl -s -X POST localhost:8080/checkout \
+    -H 'X-Trace-Id: deadbeefdeadbeefdeadbeefdeadbeef' | jq .
+
+Record it with Speedscale/proxymock, then in proxymock-web → Requests:
+  - add a Request Header filter on X-Trace-Id (any one captured value)
+  - click the Trace toggle to see that request's full waterfall.
+EOF

--- a/scenarios/trace-demo/k8s/gateway.yaml
+++ b/scenarios/trace-demo/k8s/gateway.yaml
@@ -1,0 +1,66 @@
+# Gateway: the trace entry point. Fans every /checkout out to cart, pricing,
+# payment, and shipping, propagating trace context to each.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gateway
+  namespace: trace-demo
+  annotations:
+    # Speedscale/proxymock capture: record this pod's inbound + outbound traffic.
+    capture.speedscale.com/enabled: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gateway
+  template:
+    metadata:
+      labels:
+        app: gateway
+    spec:
+      containers:
+        - name: gateway
+          image: trace-demo:local
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: ROLE
+              value: "gateway"
+            - name: CART_URL
+              value: "http://cart"
+            - name: PRICING_URL
+              value: "http://pricing"
+            - name: PAYMENT_URL
+              value: "http://payment"
+            - name: SHIPPING_URL
+              value: "http://shipping"
+          ports:
+            - containerPort: 8080
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway
+  namespace: trace-demo
+spec:
+  type: NodePort
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+      nodePort: 30090
+  selector:
+    app: gateway

--- a/scenarios/trace-demo/k8s/kustomization.yaml
+++ b/scenarios/trace-demo/k8s/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: trace-demo
+resources:
+  - namespace.yaml
+  - gateway.yaml
+  - backends.yaml
+  - loadgen.yaml

--- a/scenarios/trace-demo/k8s/loadgen.yaml
+++ b/scenarios/trace-demo/k8s/loadgen.yaml
@@ -1,0 +1,39 @@
+# Load generator (the client). Drives at least COUNT distinct traces through the
+# gateway, then loops so any recording window captures traffic. Deployed as its
+# own unit and capture-enabled, so the client side of every call is recorded too.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loadgen
+  namespace: trace-demo
+  annotations:
+    capture.speedscale.com/enabled: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: loadgen
+  template:
+    metadata:
+      labels:
+        app: loadgen
+    spec:
+      containers:
+        - name: loadgen
+          image: trace-demo:local
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: ROLE
+              value: "loadgen"
+            - name: GATEWAY_URL
+              value: "http://gateway"
+            # At least 100 distinct traces per pass (overshoot for headroom).
+            - name: COUNT
+              value: "150"
+            - name: DELAY_MS
+              value: "150"
+            - name: LOOP
+              value: "true"
+          resources:
+            requests: { cpu: 10m, memory: 24Mi }
+            limits: { cpu: 100m, memory: 64Mi }

--- a/scenarios/trace-demo/k8s/namespace.yaml
+++ b/scenarios/trace-demo/k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: trace-demo

--- a/scenarios/trace-demo/record-local.sh
+++ b/scenarios/trace-demo/record-local.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Record the trace-demo stack locally with `proxymock record` (no Kubernetes).
+#
+# Starts the backend services, then records the gateway: proxymock's inbound
+# proxy (:4143) captures the request into the gateway, and its outbound proxy
+# (:4140) captures the gateway's fan-out to the backends. pricing's call to tax
+# is captured too by routing pricing's outbound through the same :4140 proxy.
+#
+# Downstream URLs use $(hostname), NOT localhost: Go's HTTP client bypasses the
+# proxy env vars for loopback hosts, so calls to localhost would never reach
+# proxymock's outbound proxy and wouldn't be recorded.
+#
+# Run this in one terminal, then drive traffic in another:
+#   ROLE=loadgen GATEWAY_URL=http://localhost:4143 COUNT=150 LOOP=false /tmp/trace-demo
+# Then view what you captured:
+#   proxymock web
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BIN=/tmp/trace-demo
+HOST="$(hostname)"
+
+echo "Building $BIN..."
+( cd "$DIR/app" && go build -o "$BIN" . )
+
+echo "Starting backends (cart, tax, payment, shipping, pricing)..."
+ROLE=cart     PORT=8081 "$BIN" &
+ROLE=tax      PORT=8085 "$BIN" &
+ROLE=payment  PORT=8083 "$BIN" &
+ROLE=shipping PORT=8084 "$BIN" &
+# pricing -> tax: route pricing's outbound through proxymock's outbound proxy so
+# the second-level hop is recorded as well.
+http_proxy=http://localhost:4140 https_proxy=http://localhost:4140 \
+  ROLE=pricing PORT=8082 TAX_URL="http://$HOST:8085" "$BIN" &
+trap 'kill $(jobs -p) 2>/dev/null || true' EXIT
+sleep 1
+
+echo "Recording the gateway with proxymock (Ctrl-C to stop)..."
+echo "Drive traffic from another terminal at http://localhost:4143"
+proxymock record --app-port 8080 -- \
+  env ROLE=gateway PORT=8080 \
+      CART_URL="http://$HOST:8081" PRICING_URL="http://$HOST:8082" \
+      PAYMENT_URL="http://$HOST:8083" SHIPPING_URL="http://$HOST:8084" \
+      "$BIN"


### PR DESCRIPTION
## What

A new `scenarios/trace-demo` stack that emits **real distributed traces** when recorded with Speedscale/proxymock — purpose-built to generate test data for the proxymock-web **Trace** waterfall.

One `/checkout` fans out across six services and two levels of depth:

```
loadgen ─▶ gateway ─┬─▶ cart
                    ├─▶ pricing ─▶ tax
                    ├─▶ payment        ← fails ~12% (error spans)
                    └─▶ shipping
```

Every hop propagates W3C `traceparent`, Zipkin **B3**, and a stable **`X-Trace-Id`** that is constant across all hops of one request. `X-Trace-Id` is the grouping key you filter on; the B3 span ids give the waterfall its exact parent/child nesting.

It's one Go binary; `ROLE` picks the service (or the `loadgen` client), so the whole stack is a single image.

## 100+ traces

`loadgen` drives `COUNT` (default **150**) distinct traces per pass, then loops so any recording window sees traffic. ~25s per pass at the default spacing.

## Deploy (minikube)

```bash
cd scenarios/trace-demo && make minikube
```

Builds the image into minikube's Docker (no registry) and brings up the **client** (`loadgen`) and **servers** in the `trace-demo` namespace, all annotated `capture.speedscale.com/enabled: "true"` so both sides of every call record. `make undeploy` tears it down. A no-Kubernetes local run (for the proxymock CLI) is in the README.

## Use with the Trace view

Record the namespace, then in proxymock-web → Requests add a Request Header filter on `X-Trace-Id` and click **Trace**. (Pairs with proxymock-web MR for the Trace waterfall feature.)

## Verification

- `gofmt` / `go vet` / unit tests (trace propagation round-trip) pass
- Ran the full 6-service graph locally: fan-out + `pricing → tax` propagation + loadgen summary (`8 traces sent (0 failed)`)
- `kubectl kustomize` renders 14 resources; `docker build` produces an 18.8 MB image; container smoke test serves `/health` + `/cart/validate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)