### PR TITLE
Add Micronaut OTLP repro

### DIFF
--- a/java/otel-grpc-repro/README.md
+++ b/java/otel-grpc-repro/README.md
@@ -1,0 +1,77 @@
+# Micronaut OTLP/gRPC Java Agent Repro
+
+This repro isolates a Micronaut OpenTelemetry exporter using the plaintext OTLP/gRPC path:
+
+- `io.opentelemetry:opentelemetry-exporter-otlp:1.54.1`
+- `io.micronaut.tracing:micronaut-tracing-opentelemetry-http:7.2.0`
+- `OTEL_EXPORTER_OTLP_ENDPOINT=http://tracing-agent.tracing:4317`
+- one deployment without the nettap JVM agent
+- one deployment with `-javaagent:/nettap-agent/nettap-agent.jar=speedscale-nettap.speedscale:8000`
+
+The app exports a span every second, can generate burst traffic through `/burst?count=N`, and logs each successful emission. The local collector accepts plaintext OTLP/gRPC on `tracing-agent.tracing:4317` and logs received spans through its debug exporter.
+
+## Build
+
+```bash
+cd java/otel-grpc-repro
+docker build -t localhost/micronaut-otel-grpc-repro:latest app
+```
+
+If the cluster cannot see the local Docker daemon, load or push the image for that cluster first.
+
+## Smoke Test
+
+```bash
+cd java/otel-grpc-repro
+./verify.sh
+```
+
+The script renders the Kubernetes overlay, builds the Docker image, runs the app locally, checks `/health`, and confirms span emission in logs.
+
+## Deploy
+
+```bash
+kubectl apply -k k8s
+kubectl -n tracing rollout status deployment/tracing-agent
+kubectl -n otel-grpc-repro rollout status deployment/micronaut-otel-noagent
+kubectl -n otel-grpc-repro rollout status deployment/micronaut-otel-agent
+```
+
+The agent deployment expects Speedscale nettap to be installed in the cluster with `speedscale-nettap.speedscale:8000` reachable. Change `NETTAP_JAVAAGENT_ENDPOINT` in `k8s/micronaut-otel-agent.yaml` if the service name differs.
+
+## Check
+
+Compare app logs:
+
+```bash
+kubectl -n otel-grpc-repro logs deployment/micronaut-otel-noagent --tail=100
+kubectl -n otel-grpc-repro logs deployment/micronaut-otel-agent --tail=100
+```
+
+Check collector receipt:
+
+```bash
+kubectl -n tracing logs deployment/tracing-agent --tail=200 | grep repro.otlp.grpc.export
+```
+
+Generate burst traffic through the Java-agent deployment:
+
+```bash
+kubectl -n otel-grpc-repro port-forward svc/micronaut-otel-agent 18082:8080
+curl -sS 'http://127.0.0.1:18082/burst?count=50000'
+```
+
+Generate the same burst against the no-agent baseline:
+
+```bash
+kubectl -n otel-grpc-repro port-forward svc/micronaut-otel-noagent 18083:8080
+curl -sS 'http://127.0.0.1:18083/burst?count=50000'
+```
+
+Expected healthy result:
+
+- both deployments log steady `emitted span` messages
+- collector logs spans from both `micronaut-otel-noagent` and `micronaut-otel-agent`
+- agent deployment does not log OTLP export failures, connection resets, or gRPC `UNAVAILABLE`
+
+If export failures reproduce, the useful evidence is the agent deployment logs plus collector logs from the same time window.

--- a/java/otel-grpc-repro/app/Dockerfile
+++ b/java/otel-grpc-repro/app/Dockerfile
@@ -1,0 +1,11 @@
+FROM gradle:8.10.2-jdk17 AS build
+WORKDIR /workspace
+COPY settings.gradle build.gradle ./
+COPY src ./src
+RUN gradle --no-daemon clean shadowJar
+
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+COPY --from=build /workspace/build/libs/otel-grpc-repro-0.1.0.jar /app/otel-grpc-repro.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "/app/otel-grpc-repro.jar"]

--- a/java/otel-grpc-repro/app/build.gradle
+++ b/java/otel-grpc-repro/app/build.gradle
@@ -1,0 +1,46 @@
+plugins {
+    id "java"
+    id "application"
+    id "com.github.johnrengelman.shadow" version "8.1.1"
+}
+
+group = "com.speedscale.repro"
+version = "0.1.0"
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+dependencies {
+    annotationProcessor platform("io.micronaut.platform:micronaut-platform:4.9.4")
+    annotationProcessor "io.micronaut:micronaut-inject-java"
+    annotationProcessor "io.micronaut.serde:micronaut-serde-processor"
+
+    implementation platform("io.micronaut.platform:micronaut-platform:4.9.4")
+    implementation "io.micronaut:micronaut-http-server-netty"
+    implementation "io.micronaut:micronaut-runtime"
+    implementation "io.micronaut.serde:micronaut-serde-jackson"
+    implementation "io.micronaut.tracing:micronaut-tracing-opentelemetry-http:7.2.0"
+    implementation "io.opentelemetry:opentelemetry-api:1.54.1"
+    implementation "io.opentelemetry:opentelemetry-sdk:1.54.1"
+    implementation "io.opentelemetry:opentelemetry-exporter-otlp:1.54.1"
+
+    runtimeOnly "ch.qos.logback:logback-classic:1.5.18"
+}
+
+application {
+    mainClass = "com.speedscale.repro.OtelGrpcReproApplication"
+}
+
+tasks.named("shadowJar") {
+    archiveClassifier.set("")
+    mergeServiceFiles()
+    manifest {
+        attributes "Main-Class": application.mainClass.get()
+    }
+}
+
+tasks.named("build") {
+    dependsOn tasks.named("shadowJar")
+}

--- a/java/otel-grpc-repro/app/settings.gradle
+++ b/java/otel-grpc-repro/app/settings.gradle
@@ -1,0 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        mavenCentral()
+    }
+}
+
+rootProject.name = "otel-grpc-repro"

--- a/java/otel-grpc-repro/app/src/main/java/com/speedscale/repro/OtelGrpcReproApplication.java
+++ b/java/otel-grpc-repro/app/src/main/java/com/speedscale/repro/OtelGrpcReproApplication.java
@@ -1,0 +1,9 @@
+package com.speedscale.repro;
+
+import io.micronaut.runtime.Micronaut;
+
+public class OtelGrpcReproApplication {
+    public static void main(String[] args) {
+        Micronaut.run(OtelGrpcReproApplication.class, args);
+    }
+}

--- a/java/otel-grpc-repro/app/src/main/java/com/speedscale/repro/ReproController.java
+++ b/java/otel-grpc-repro/app/src/main/java/com/speedscale/repro/ReproController.java
@@ -1,0 +1,49 @@
+package com.speedscale.repro;
+
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Produces;
+import io.micronaut.http.annotation.QueryValue;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+
+@Controller
+public class ReproController {
+    private final SpanEmitter emitter;
+
+    public ReproController(SpanEmitter emitter) {
+        this.emitter = emitter;
+    }
+
+    @Get("/health")
+    @Produces(MediaType.APPLICATION_JSON)
+    Map<String, Object> health() {
+        return Map.of("status", "ok", "emitted", emitter.count());
+    }
+
+    @Get("/emit")
+    @Produces(MediaType.APPLICATION_JSON)
+    Map<String, Object> emit() {
+        return Map.of("emitted", emitter.emitSpan("http"));
+    }
+
+    @Get("/burst{?count}")
+    @Produces(MediaType.APPLICATION_JSON)
+    Map<String, Object> burst(@QueryValue(defaultValue = "1000") int count) {
+        int boundedCount = Math.max(1, Math.min(count, 50_000));
+        Instant start = Instant.now();
+        long lastSequence = 0;
+        for (int i = 0; i < boundedCount; i++) {
+            lastSequence = emitter.emitSpan("burst");
+        }
+
+        return Map.of(
+            "requested", count,
+            "emitted", boundedCount,
+            "lastSequence", lastSequence,
+            "elapsedMillis", Duration.between(start, Instant.now()).toMillis()
+        );
+    }
+}

--- a/java/otel-grpc-repro/app/src/main/java/com/speedscale/repro/SpanEmitter.java
+++ b/java/otel-grpc-repro/app/src/main/java/com/speedscale/repro/SpanEmitter.java
@@ -1,0 +1,112 @@
+package com.speedscale.repro;
+
+import io.micronaut.scheduling.annotation.Scheduled;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import jakarta.inject.Singleton;
+import java.time.Instant;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Singleton
+public class SpanEmitter {
+    private static final Logger logger = LoggerFactory.getLogger(SpanEmitter.class);
+    private static final String DEFAULT_ENDPOINT = "http://tracing-agent.tracing:4317";
+    private static final String DEFAULT_SERVICE_NAME = "micronaut-otel-grpc-repro";
+
+    private final Tracer tracer;
+    private final AtomicLong count = new AtomicLong();
+
+    public SpanEmitter() {
+        OpenTelemetry openTelemetry = openTelemetry();
+        this.tracer = openTelemetry.getTracer("micronaut-otel-grpc-repro");
+    }
+
+    @Scheduled(initialDelay = "2s", fixedDelay = "1s")
+    void emitScheduledSpan() {
+        emitSpan("scheduled");
+    }
+
+    long emitSpan(String trigger) {
+        long sequence = count.incrementAndGet();
+        Span span = tracer.spanBuilder("repro.otlp.grpc.export")
+            .setSpanKind(SpanKind.INTERNAL)
+            .setAttribute("repro.trigger", trigger)
+            .setAttribute("repro.sequence", sequence)
+            .setAttribute("repro.time", Instant.now().toString())
+            .startSpan();
+        try {
+            span.addEvent("span.body", Attributes.of(
+                AttributeKey.stringKey("message"),
+                "plaintext otlp grpc export"
+            ));
+            logger.info("emitted span sequence={} trigger={}", sequence, trigger);
+            return sequence;
+        } catch (RuntimeException e) {
+            span.recordException(e);
+            throw e;
+        } finally {
+            span.end();
+        }
+    }
+
+    long count() {
+        return count.get();
+    }
+
+    private static OpenTelemetry openTelemetry() {
+        String endpoint = env("OTEL_EXPORTER_OTLP_ENDPOINT", DEFAULT_ENDPOINT);
+        String serviceName = env("OTEL_SERVICE_NAME", DEFAULT_SERVICE_NAME);
+        Resource resource = Resource.getDefault().merge(Resource.create(Attributes.of(
+            AttributeKey.stringKey("service.name"),
+            serviceName,
+            AttributeKey.stringKey("service.namespace"),
+            "otel-grpc-repro"
+        )));
+
+        SdkTracerProvider provider = SdkTracerProvider.builder()
+            .setResource(resource)
+            .addSpanProcessor(BatchSpanProcessor.builder(OtlpGrpcSpanExporter.builder()
+                    .setEndpoint(endpoint)
+                    .setTimeout(Duration.ofSeconds(5))
+                    .build())
+                .setScheduleDelay(Duration.ofMillis(envInt("OTEL_BSP_SCHEDULE_DELAY_MS", 1000)))
+                .setMaxQueueSize(envInt("OTEL_BSP_MAX_QUEUE_SIZE", 2048))
+                .setMaxExportBatchSize(envInt("OTEL_BSP_MAX_EXPORT_BATCH_SIZE", 512))
+                .build())
+            .build();
+
+        Runtime.getRuntime().addShutdownHook(new Thread(provider::close));
+
+        return OpenTelemetrySdk.builder()
+            .setTracerProvider(provider)
+            .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+            .build();
+    }
+
+    private static String env(String name, String fallback) {
+        String value = System.getenv(name);
+        return value == null || value.isBlank() ? fallback : value;
+    }
+
+    private static int envInt(String name, int fallback) {
+        String value = System.getenv(name);
+        if (value == null || value.isBlank()) {
+            return fallback;
+        }
+        return Integer.parseInt(value);
+    }
+}

--- a/java/otel-grpc-repro/app/src/main/resources/application.yml
+++ b/java/otel-grpc-repro/app/src/main/resources/application.yml
@@ -1,0 +1,17 @@
+micronaut:
+  application:
+    name: ${OTEL_SERVICE_NAME:micronaut-otel-grpc-repro}
+  server:
+    port: 8080
+
+otel:
+  exporter:
+    otlp:
+      protocol: grpc
+      endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:`http://tracing-agent.tracing:4317`}
+  traces:
+    exporter: otlp
+    sampler:
+      type: always_on
+  propagation:
+    type: tracecontext

--- a/java/otel-grpc-repro/app/src/main/resources/logback.xml
+++ b/java/otel-grpc-repro/app/src/main/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="io.opentelemetry.exporter" level="DEBUG"/>
+    <logger name="com.speedscale.repro" level="INFO"/>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/java/otel-grpc-repro/k8s/kustomization.yaml
+++ b/java/otel-grpc-repro/k8s/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespaces.yaml
+  - tracing-agent.yaml
+  - micronaut-otel-noagent.yaml
+  - micronaut-otel-agent.yaml

--- a/java/otel-grpc-repro/k8s/micronaut-otel-agent.yaml
+++ b/java/otel-grpc-repro/k8s/micronaut-otel-agent.yaml
@@ -1,0 +1,84 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: micronaut-otel-agent
+  namespace: otel-grpc-repro
+  labels:
+    app: micronaut-otel-agent
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: micronaut-otel-agent
+  template:
+    metadata:
+      labels:
+        app: micronaut-otel-agent
+    spec:
+      initContainers:
+        - name: copy-nettap-agent
+          image: gcr.io/speedscale/nettap:v0.1.37
+          command:
+            - sh
+            - -c
+            - |
+              cp /nettap-agent/nettap-agent.jar /agent/nettap-agent.jar ||
+              cp /nettap-agent.jar /agent/nettap-agent.jar ||
+              find / -name nettap-agent.jar -exec cp {} /agent/nettap-agent.jar \; -quit
+          volumeMounts:
+            - name: nettap-agent
+              mountPath: /agent
+      containers:
+        - name: app
+          image: localhost/micronaut-otel-grpc-repro:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: OTEL_SERVICE_NAME
+              value: micronaut-otel-agent
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://tracing-agent.tracing:4317
+            - name: OTEL_BSP_SCHEDULE_DELAY_MS
+              value: "100"
+            - name: OTEL_BSP_MAX_QUEUE_SIZE
+              value: "100000"
+            - name: OTEL_BSP_MAX_EXPORT_BATCH_SIZE
+              value: "512"
+            - name: NETTAP_JAVAAGENT_ENDPOINT
+              value: speedscale-nettap.speedscale:8000
+            - name: JAVA_TOOL_OPTIONS
+              value: -javaagent:/nettap-agent/nettap-agent.jar=speedscale-nettap.speedscale:8000
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          volumeMounts:
+            - name: nettap-agent
+              mountPath: /nettap-agent
+              readOnly: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 512Mi
+      volumes:
+        - name: nettap-agent
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: micronaut-otel-agent
+  namespace: otel-grpc-repro
+spec:
+  selector:
+    app: micronaut-otel-agent
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080

--- a/java/otel-grpc-repro/k8s/micronaut-otel-noagent.yaml
+++ b/java/otel-grpc-repro/k8s/micronaut-otel-noagent.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: micronaut-otel-noagent
+  namespace: otel-grpc-repro
+  labels:
+    app: micronaut-otel-noagent
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: micronaut-otel-noagent
+  template:
+    metadata:
+      labels:
+        app: micronaut-otel-noagent
+    spec:
+      containers:
+        - name: app
+          image: localhost/micronaut-otel-grpc-repro:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: OTEL_SERVICE_NAME
+              value: micronaut-otel-noagent
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://tracing-agent.tracing:4317
+            - name: OTEL_BSP_SCHEDULE_DELAY_MS
+              value: "100"
+            - name: OTEL_BSP_MAX_QUEUE_SIZE
+              value: "100000"
+            - name: OTEL_BSP_MAX_EXPORT_BATCH_SIZE
+              value: "512"
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 512Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: micronaut-otel-noagent
+  namespace: otel-grpc-repro
+spec:
+  selector:
+    app: micronaut-otel-noagent
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080

--- a/java/otel-grpc-repro/k8s/namespaces.yaml
+++ b/java/otel-grpc-repro/k8s/namespaces.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tracing
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: otel-grpc-repro

--- a/java/otel-grpc-repro/k8s/tracing-agent.yaml
+++ b/java/otel-grpc-repro/k8s/tracing-agent.yaml
@@ -1,0 +1,91 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tracing-agent-conf
+  namespace: tracing
+data:
+  otel-collector-config.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+
+    processors:
+      batch: {}
+
+    exporters:
+      debug:
+        verbosity: detailed
+
+    extensions:
+      health_check:
+        endpoint: 0.0.0.0:13133
+
+    service:
+      extensions: [health_check]
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [debug]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tracing-agent
+  namespace: tracing
+  labels:
+    app: tracing-agent
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tracing-agent
+  template:
+    metadata:
+      labels:
+        app: tracing-agent
+    spec:
+      containers:
+        - name: collector
+          image: otel/opentelemetry-collector-contrib:0.120.0
+          args:
+            - --config=/conf/otel-collector-config.yaml
+          ports:
+            - name: otlp-grpc
+              containerPort: 4317
+            - name: health
+              containerPort: 13133
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          volumeMounts:
+            - name: config
+              mountPath: /conf
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              memory: 256Mi
+      volumes:
+        - name: config
+          configMap:
+            name: tracing-agent-conf
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tracing-agent
+  namespace: tracing
+spec:
+  selector:
+    app: tracing-agent
+  ports:
+    - name: otlp-grpc
+      port: 4317
+      targetPort: 4317

--- a/java/otel-grpc-repro/verify.sh
+++ b/java/otel-grpc-repro/verify.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Proves: the Micronaut OTLP/gRPC repro renders, builds, starts, and emits spans.
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+REPRO_DIR="$ROOT/java/otel-grpc-repro"
+IMAGE="localhost/micronaut-otel-grpc-repro:latest"
+PORT="${PORT:-18081}"
+CID=""
+
+cleanup() {
+  if [[ -n "$CID" ]]; then
+    docker rm -f "$CID" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+echo "Checking Kubernetes overlay..."
+kubectl kustomize "$REPRO_DIR/k8s" >/tmp/otel-grpc-repro-rendered.yaml
+
+echo "Building repro image..."
+docker build -t "$IMAGE" "$REPRO_DIR/app" >/tmp/otel-grpc-repro-docker-build.log
+
+echo "Starting repro container..."
+CID="$(docker run -d -p "$PORT:8080" -e OTEL_EXPORTER_OTLP_ENDPOINT=http://host.docker.internal:4317 "$IMAGE")"
+
+echo "Waiting for health endpoint..."
+for _ in $(seq 1 30); do
+  if curl -sf "http://localhost:$PORT/health" >/tmp/otel-grpc-repro-health.json; then
+    break
+  fi
+  sleep 1
+done
+
+if ! curl -sf "http://localhost:$PORT/health" >/tmp/otel-grpc-repro-health.json; then
+  echo "FAIL: /health did not respond"
+  docker logs "$CID" || true
+  exit 1
+fi
+
+if ! grep -q '"status":"ok"' /tmp/otel-grpc-repro-health.json; then
+  echo "FAIL: /health response did not come from the repro app"
+  cat /tmp/otel-grpc-repro-health.json
+  exit 1
+fi
+
+sleep 3
+docker logs "$CID" >/tmp/otel-grpc-repro-container.log 2>&1
+
+if ! grep -q "emitted span" /tmp/otel-grpc-repro-container.log; then
+  echo "FAIL: container started but did not emit spans"
+  cat /tmp/otel-grpc-repro-container.log
+  exit 1
+fi
+
+echo "PASS: overlay renders, image builds, app starts, /health responds, and spans are emitted"
+cat /tmp/otel-grpc-repro-health.json
+echo


### PR DESCRIPTION
## Summary

Adds a self-contained Java/Micronaut demo for plaintext OTLP/gRPC span export with and without the nettap JVM agent:

- Micronaut app using OpenTelemetry OTLP exporter
- local OTLP collector deployment
- Kubernetes no-agent and Java-agent deployments for comparison
- `/burst?count=N` endpoint for high-volume span generation
- `verify.sh` smoke test for render/build/runtime span emission

## Verification

```bash
java/otel-grpc-repro/verify.sh
```

Passed locally: overlay render, Docker image build, container startup, `/health`, and span emission logs.
