### PR TITLE
[codex] Fix Java Trivy Jackson findings

### DIFF
--- a/.github/workflows/dependency-security.yml
+++ b/.github/workflows/dependency-security.yml
@@ -74,6 +74,11 @@ jobs:
           java:
             - *workflow
             - '**/pom.xml'
+            - '**/build.gradle'
+            - '**/build.gradle.kts'
+            - '**/settings.gradle'
+            - '**/settings.gradle.kts'
+            - '**/gradle.lockfile'
 
   node:
     name: Node.js (npm audit)

--- a/java-auth/client/pom.xml
+++ b/java-auth/client/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.21.1</version>
+            <version>2.22.0</version>
         </dependency>
     </dependencies>
     

--- a/java-auth/server/pom.xml
+++ b/java-auth/server/pom.xml
@@ -15,8 +15,8 @@
     <description>Authentication microservice for Spring Boot</description>
     <properties>
         <java.version>17</java.version>
-        <!-- Boot 3.5.x still manages a jackson-core affected by GHSA-72hv-8253-57qq -->
-        <jackson-bom.version>2.21.1</jackson-bom.version>
+        <!-- Boot 3.5.x still manages jackson artifacts affected by open CVEs -->
+        <jackson-bom.version>2.22.0</jackson-bom.version>
         <!-- Boot 3.5.14 manages tomcat 10.1.54; CVE-2026-41293 et al. need 10.1.55 -->
         <tomcat.version>10.1.55</tomcat.version>
         <!-- transitive commons-lang3 3.17.0 has CVE-2025-48924 -->

--- a/java/server/pom.xml
+++ b/java/server/pom.xml
@@ -17,8 +17,8 @@
 		<java.version>17</java.version>
 		<gatling.version>3.10.3</gatling.version>
 		<gatling-maven-plugin.version>4.4.0</gatling-maven-plugin.version>
-		<!-- Boot 3.5.x still manages a jackson-core affected by GHSA-72hv-8253-57qq -->
-		<jackson-bom.version>2.21.1</jackson-bom.version>
+		<!-- Boot 3.5.x still manages jackson artifacts affected by open CVEs -->
+		<jackson-bom.version>2.22.0</jackson-bom.version>
 		<!-- Boot 3.5.14 manages tomcat 10.1.54; CVE-2026-41293 et al. need 10.1.55 -->
 		<tomcat.version>10.1.55</tomcat.version>
 	</properties>


### PR DESCRIPTION
## What changed

- Bumped the Java and java-auth Jackson overrides from 2.21.1 to 2.22.0.
- Added Gradle Java manifests to the Dependency Security PR path filter.

## Why

The latest master Dependency Security run failed in Java Trivy on `com.fasterxml.jackson.core:jackson-databind` 2.21.1. PR #178 also showed a coverage gap: Gradle Java changes did not trigger the Java security job on pull requests.

## Validation

- `mvn dependency:resolve` in `java/server`, `java-auth/server`, and `java-auth/client`
- `trivy fs --scanners vuln --pkg-types library --ignore-unfixed --offline-scan --exit-code 1 java`
- `trivy fs --scanners vuln --pkg-types library --ignore-unfixed --offline-scan --exit-code 1 java-auth`
- `mvn test` in `java/server`, `java-auth/server`, and `java-auth/client`
- `mvn package -DskipTests` in `java/server`, `java-auth/server`, and `java-auth/client`

Note: `make test-java` currently fails because `java/Makefile` has no `test` target; Maven tests were run directly.
