### PR TITLE
Add user-journey demo: trace a customer without trace IDs

### DIFF
--- a/scenarios/otel-trace-replay-gate/README.md
+++ b/scenarios/otel-trace-replay-gate/README.md
@@ -16,7 +16,18 @@ scenarios/otel-trace-replay-gate/
   otel/collector-replay-candidates.yaml
   github-actions/replay-gate.yml
   run-example.sh
+  user-journey/                 # trace one customer across 4 services, no trace IDs
 ```
+
+## Companion demo: trace a customer without traces
+
+`user-journey/` is a four-service checkout app (gateway → auth → orders →
+shipping) that threads one customer's email through HTTP headers, request
+bodies, and response bodies. Record it, then in proxymock-web apply a
+single **Full Text** filter on the email and switch to the **Trace** lens
+to see that one person's cross-service waterfall — with no trace IDs and
+no instrumentation. See `user-journey/README.md`. This is the demo behind
+the "How to trace without traces" video.
 
 ## Verified local run
 

--- a/scenarios/otel-trace-replay-gate/user-journey/.gitignore
+++ b/scenarios/otel-trace-replay-gate/user-journey/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+proxymock/
+package-lock.json

--- a/scenarios/otel-trace-replay-gate/user-journey/README.md
+++ b/scenarios/otel-trace-replay-gate/user-journey/README.md
@@ -1,0 +1,70 @@
+# User Journey — trace a customer without traces
+
+A four-service checkout app whose only job is to prove a point: you can
+follow one customer's request across every service it touches **without
+a single trace ID, span, or line of OpenTelemetry** — because proxymock
+already recorded the real traffic, and proxymock-web can filter it by any
+value in any field.
+
+```mermaid
+graph LR
+    Client -->|POST /checkout| gateway
+    gateway -->|POST /whoami| auth
+    gateway -->|POST /orders| orders
+    orders  -->|POST /ship|   shipping
+```
+
+## The one identifier, in three kinds of field
+
+Every request carries the customer's email in the ways real systems
+smear an identifier around — so a single Full Text filter has to find
+it everywhere at once:
+
+| Field kind        | Where                                            |
+| ----------------- | ------------------------------------------------ |
+| HTTP header       | `X-User-Email` on every hop                      |
+| Request body      | `{ "email": ... }` on checkout / whoami / orders / ship |
+| Response body     | echoed back by auth / orders / shipping          |
+
+A W3C `traceparent` is propagated too — but only so the waterfall can
+*nest* the hops. You never filter on it. That is the whole idea: **the
+grouping key is business data (the email), not a trace ID.**
+
+## Run it
+
+```bash
+npm install
+./record-all.sh          # records ~40 checkouts for 5 named customers
+proxymock web --in .     # workspace root — the dir that holds proxymock/
+```
+
+`record-all.sh` runs one `proxymock record` per service into a shared
+workspace (see the header comment in the script for the port map and the
+`*.localtest.me` routing trick that needs no `/etc/hosts` and no sudo).
+
+## See one customer's journey
+
+In proxymock-web:
+
+1. **Filters → Full Text → contains → `ada.lovelace@example.com` → Apply.**
+   The grid collapses from every customer's traffic to just Ada's —
+   matched across headers, request bodies, and response bodies.
+2. Switch the Requests view to the **Trace** lens.
+3. Read the waterfall: `gateway → auth`, `gateway → orders`,
+   `orders → shipping`, time-ordered and nested, for that one person.
+
+Swap in `grace.hopper@example.com`, `alan.turing@example.com`,
+`katherine.johnson@example.com`, or `margaret.hamilton@example.com` to
+watch a different customer's path.
+
+## Plain local run (no proxymock)
+
+```bash
+SERVICE=auth     PORT=3002 node server.js &
+SERVICE=shipping PORT=3004 node server.js &
+SERVICE=orders   PORT=3003 node server.js &
+SERVICE=gateway  PORT=3001 node server.js &
+curl -s localhost:3001/checkout -H 'content-type: application/json' \
+  -H 'x-user-email: ada.lovelace@example.com' \
+  -d '{"email":"ada.lovelace@example.com","cart":[{"sku":"kbd-01","price":79}]}' | jq
+```

--- a/scenarios/otel-trace-replay-gate/user-journey/loadgen.js
+++ b/scenarios/otel-trace-replay-gate/user-journey/loadgen.js
@@ -1,0 +1,66 @@
+// Drives realistic checkout traffic for a handful of named customers so
+// that filtering proxymock-web down to ONE email isolates that person's
+// journey across all four services.
+//
+//   GATEWAY_URL   where to send /checkout (default proxymock inbound :4143)
+//   COUNT         number of checkouts to drive (default 40)
+//   CONCURRENCY   parallel workers (default 8)
+
+const GATEWAY_URL = process.env.GATEWAY_URL || 'http://localhost:4143';
+const COUNT = Number(process.env.COUNT || 40);
+const CONCURRENCY = Number(process.env.CONCURRENCY || 8);
+
+// The hero of the video is ada.lovelace@example.com — the rest are noise
+// that a single Full Text filter has to cut through.
+const USERS = [
+  'ada.lovelace@example.com',
+  'grace.hopper@example.com',
+  'alan.turing@example.com',
+  'katherine.johnson@example.com',
+  'margaret.hamilton@example.com',
+];
+
+const CATALOG = [
+  { sku: 'kbd-01', price: 79.0 },
+  { sku: 'mouse-02', price: 39.5 },
+  { sku: 'monitor-03', price: 219.0 },
+  { sku: 'dock-04', price: 129.0 },
+];
+
+const hex = (n) => Array.from({ length: n }, () => Math.floor(Math.random() * 16).toString(16)).join('');
+const traceparent = () => `00-${hex(32)}-${hex(16)}-01`;
+const pick = (a) => a[Math.floor(Math.random() * a.length)];
+
+async function checkout(i) {
+  const email = pick(USERS);
+  const cart = [pick(CATALOG), pick(CATALOG)];
+  try {
+    const res = await fetch(`${GATEWAY_URL}/checkout`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-user-email': email,
+        'traceparent': traceparent(),
+      },
+      body: JSON.stringify({ email, cart }),
+    });
+    const body = await res.json();
+    console.log(`#${i} ${res.status} ${email} -> ${body.orderId || 'ERR'}`);
+  } catch (err) {
+    console.log(`#${i} FAIL ${email} ${err.message}`);
+  }
+}
+
+async function main() {
+  let next = 0;
+  const worker = async () => {
+    while (next < COUNT) {
+      const i = next++;
+      await checkout(i);
+    }
+  };
+  await Promise.all(Array.from({ length: CONCURRENCY }, worker));
+  console.log(`done: ${COUNT} checkouts against ${GATEWAY_URL}`);
+}
+
+main();

--- a/scenarios/otel-trace-replay-gate/user-journey/package.json
+++ b/scenarios/otel-trace-replay-gate/user-journey/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "user-journey",
+  "version": "1.0.0",
+  "description": "Four-service checkout demo that threads a customer email through headers, request bodies, and response bodies — for tracing a user without trace IDs in proxymock-web",
+  "type": "module",
+  "scripts": {
+    "start": "node server.js",
+    "loadgen": "node loadgen.js"
+  },
+  "author": "speedscale",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "axios": "^1.9.0",
+    "express": "^5.2.1",
+    "morgan": "^1.11.0"
+  }
+}

--- a/scenarios/otel-trace-replay-gate/user-journey/record-all.sh
+++ b/scenarios/otel-trace-replay-gate/user-journey/record-all.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# Records the four-service checkout journey into ONE shared proxymock
+# workspace so proxymock-web can draw a cross-service waterfall for a
+# single customer — with NO trace IDs and NO code instrumentation.
+#
+# How it works (verified locally against proxymock v2.5.709):
+#   * one `proxymock record` per service, each with its own in/out/health
+#     ports, sharing one --out workspace. The waterfall's Service column
+#     is uniform per record session, so N services == N sessions.
+#   * each caller reaches the next service by a *.localtest.me hostname
+#     (public DNS -> 127.0.0.1, so NO /etc/hosts and NO sudo) pointed at
+#     that service's proxymock INBOUND port. Every hop is therefore
+#     recorded on both sides: the caller's OUTBOUND (host=<svc>.localtest.me)
+#     and the callee's INBOUND (host=localhost). Plain `localhost` targets
+#     get bypassed by the proxy, which is why the DNS names matter.
+#   * the propagated W3C `traceparent` lets the waterfall nest the hops.
+#     It is NOT what you filter on — the customer's email is.
+#
+# Offline? Replace the *.localtest.me names below with /etc/hosts aliases:
+#   echo '127.0.0.1 gateway.local auth.local orders.local shipping.local' | sudo tee -a /etc/hosts
+#
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUT="${OUT:-${DIR}/proxymock/user-journey}"
+LOG="${TMPDIR:-/tmp}/uj-record"
+COUNT="${COUNT:-40}"
+mkdir -p "${LOG}"
+
+echo "[1/4] Installing deps"
+npm install --prefix "${DIR}" >/dev/null
+
+echo "[2/4] Clearing stale recorders / ports"
+pkill -f 'proxymock record' >/dev/null 2>&1 || true
+pkill -f "${DIR}/server.js" >/dev/null 2>&1 || true
+sleep 2
+rm -rf "${OUT}"
+
+PIDS=()
+cleanup() {
+  kill "${PIDS[@]}" >/dev/null 2>&1 || true
+  pkill -f "${DIR}/server.js" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+#          svc      app  in    out   health  <extra env for downstreams...>
+start_svc() {
+  local svc=$1 app=$2 in=$3 out=$4 health=$5; shift 5
+  proxymock record \
+    --svc-name "${svc}" \
+    --out "${OUT}" \
+    --app-port "${app}" \
+    --proxy-in-port "${in}" \
+    --proxy-out-port "${out}" \
+    --health-port "${health}" \
+    --timeout 120s \
+    -- env SERVICE="${svc}" PORT="${app}" "$@" node "${DIR}/server.js" \
+    >"${LOG}/${svc}.log" 2>&1 &
+  PIDS+=($!)
+}
+
+echo "[3/4] Starting recorders (one proxymock per service -> ${OUT})"
+# Start leaf services first so downstream ports are live before callers.
+start_svc shipping 3004 4443 4440 5804
+start_svc auth     3002 4243 4240 5802
+start_svc orders   3003 4343 4340 5803 SHIPPING_URL=http://shipping.localtest.me:4443
+start_svc gateway  3001 4143 4140 5801 AUTH_URL=http://auth.localtest.me:4243 ORDERS_URL=http://orders.localtest.me:4343
+sleep 11
+
+echo "[4/4] Driving ${COUNT} customer checkouts through the edge (:4143)"
+GATEWAY_URL=http://localhost:4143 COUNT="${COUNT}" node "${DIR}/loadgen.js"
+
+# Let the recorders flush, then stop them.
+sleep 2
+cleanup
+trap - EXIT
+wait 2>/dev/null || true
+
+echo
+echo "Recorded to: ${OUT}"
+echo "Services:    $(grep -rho 'k8sAppLabel=[a-z]*' "${OUT}" 2>/dev/null | sort -u | sed 's/k8sAppLabel=//' | paste -sd', ' -)"
+echo
+# proxymock web wants the workspace ROOT (the dir that contains proxymock/),
+# not the recording dir itself.
+echo "View it:     proxymock web --in ${OUT%/proxymock/*}"
+echo
+echo "Then in proxymock-web:"
+echo "  1. Filters -> Full Text -> contains -> ada.lovelace@example.com -> Apply"
+echo "  2. Switch the Requests view to the Trace lens"
+echo "  3. Read that one customer's waterfall across gateway/auth/orders/shipping"

--- a/scenarios/otel-trace-replay-gate/user-journey/server.js
+++ b/scenarios/otel-trace-replay-gate/user-journey/server.js
@@ -1,0 +1,122 @@
+// One binary, four roles. Set SERVICE to pick which service this process is.
+//
+//   SERVICE=gateway  PORT=3001   (edge; POST /checkout)
+//   SERVICE=auth     PORT=3002   (GET  /whoami)
+//   SERVICE=orders   PORT=3003   (POST /orders)
+//   SERVICE=shipping PORT=3004   (POST /ship)
+//
+// The point of this app is to thread ONE identifier — the customer's
+// email — through every field type proxymock can search:
+//
+//   * HTTP header      X-User-Email  (on every hop)
+//   * request body     { "email": ... } on checkout / orders / ship
+//   * response body    { "email": ... } echoed by auth / orders / shipping
+//
+// so that a single Full Text filter on that email in proxymock-web
+// lights up the whole transaction — no trace IDs required. A W3C
+// `traceparent` is also propagated unchanged across the transaction so
+// the waterfall can nest hops, but it is NOT what we filter on.
+
+import axios from 'axios';
+import express from 'express';
+import morgan from 'morgan';
+
+const SERVICE = process.env.SERVICE || 'gateway';
+const PORT = Number(process.env.PORT || 3001);
+
+// Downstream base URLs. record-all.sh overrides these with *.local
+// hostnames so each hop is captured against a distinct upstream host
+// (the waterfall's Host column). Defaults keep a plain `node server.js`
+// runnable on one machine.
+const AUTH_URL = process.env.AUTH_URL || 'http://localhost:3002';
+const ORDERS_URL = process.env.ORDERS_URL || 'http://localhost:3003';
+const SHIPPING_URL = process.env.SHIPPING_URL || 'http://localhost:3004';
+
+const app = express();
+app.use(express.json());
+app.use(morgan('tiny'));
+
+const hex = (n) => Array.from({ length: n }, () => Math.floor(Math.random() * 16).toString(16)).join('');
+
+// nextTraceparent keeps the incoming trace-id but mints a FRESH span-id for
+// this outbound hop. That way the caller's OUT and the callee's IN share one
+// unique span id per hop, so the trace nests as a tree. Reusing a single
+// span id across every hop (the naive "forward traceparent unchanged"
+// approach) collapses the graph and can even make the nester cycle.
+function nextTraceparent(req) {
+  const parts = String(req.get('traceparent') || '').split('-');
+  const traceId = parts.length === 4 && parts[1] ? parts[1] : hex(32);
+  return `00-${traceId}-${hex(16)}-01`;
+}
+
+// Propagate the caller's trace + identity headers to the next hop.
+function fwdHeaders(req, extra = {}) {
+  const h = { 'content-type': 'application/json', traceparent: nextTraceparent(req), ...extra };
+  const email = req.get('x-user-email');
+  if (email) h['x-user-email'] = email;
+  return h;
+}
+
+// axios (unlike node's built-in fetch) honors http_proxy / https_proxy, so
+// proxymock captures these inter-service calls on its outbound proxy.
+async function postJSON(url, body, headers) {
+  const res = await axios.post(url, body, { headers });
+  return res.data;
+}
+
+app.get('/healthz', (_req, res) => res.send({ health: 'y' }));
+
+if (SERVICE === 'gateway') {
+  // Edge service. The customer's email arrives in the request body AND
+  // an X-User-Email header, then fans out to auth -> orders -> shipping.
+  app.post('/checkout', async (req, res) => {
+    const email = req.body.email;
+
+    // Fresh headers per downstream call so each hop gets its own span id.
+    const who = await postJSON(`${AUTH_URL}/whoami`, { email }, fwdHeaders(req, { 'x-user-email': email }));
+    const order = await postJSON(`${ORDERS_URL}/orders`, {
+      email,
+      items: req.body.cart || [],
+    }, fwdHeaders(req, { 'x-user-email': email }));
+
+    res.send({
+      email,
+      status: 'confirmed',
+      roles: who.roles,
+      orderId: order.orderId,
+      total: order.total,
+      eta: order.eta,
+    });
+  });
+}
+
+if (SERVICE === 'auth') {
+  // Identity service. Reads the email from the request body (or header)
+  // and echoes it back in the RESPONSE body — so the same string is
+  // present on both sides of this hop.
+  app.post('/whoami', (req, res) => {
+    const email = req.body.email || req.get('x-user-email') || 'unknown';
+    res.send({ email, roles: ['customer'], verified: true });
+  });
+}
+
+if (SERVICE === 'orders') {
+  app.post('/orders', async (req, res) => {
+    const email = req.body.email;
+    const orderId = 'ord-' + Math.random().toString(36).slice(2, 10);
+    const total = (req.body.items || []).reduce((s, i) => s + (i.price || 9.99), 0) || 9.99;
+
+    const ship = await postJSON(`${SHIPPING_URL}/ship`, { email, orderId }, fwdHeaders(req));
+
+    res.send({ email, orderId, total, eta: ship.eta });
+  });
+}
+
+if (SERVICE === 'shipping') {
+  app.post('/ship', (req, res) => {
+    const email = req.body.email;
+    res.send({ email, orderId: req.body.orderId, eta: '2 business days', carrier: 'speedpost' });
+  });
+}
+
+app.listen(PORT, () => console.log(`${SERVICE} listening on :${PORT}`));


### PR DESCRIPTION
Adds `scenarios/otel-trace-replay-gate/user-journey/` — a four-service checkout app for demonstrating how to follow one customer across services in `proxymock web` **without trace IDs, OpenTelemetry, or app instrumentation**.

## The app
`gateway -> auth`, `gateway -> orders`, `orders -> shipping`. Every hop carries the customer's email in three kinds of field so a single **Full Text** filter finds it everywhere:
- HTTP header `X-User-Email`
- request bodies (`/checkout`, `/whoami`, `/orders`, `/ship`)
- response bodies (echoed by auth / orders / shipping)

A per-hop W3C `traceparent` is propagated so the Trace waterfall nests into a tree — but you filter on the email, never the trace id.

## Files
- `server.js` — one binary, four roles (`SERVICE=` env selects).
- `loadgen.js` — drives checkouts for five named customers.
- `record-all.sh` — one `proxymock record` per service into a shared workspace, routed via `*.localtest.me` (no `/etc/hosts`, no sudo). Verified end-to-end: 4 services, distinct hosts, email discoverable across header/request-body/response-body.
- `README.md` + a pointer from the scenario README.

## Verified
App runs end-to-end; `record-all.sh` captures all four services; `proxymock web` filters to one customer and renders the cross-service waterfall.

Backs the "How to trace without traces" video and the `speedscale/docs` guide PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)