### PR TITLE
Fix node-mariadb demo recording so MariaDB SQL is actually captured

### DIFF
--- a/node-mariadb/Makefile
+++ b/node-mariadb/Makefile
@@ -130,10 +130,11 @@ demo-multi-user: build certs ## Run auth + multi-user proxymock demo flow
 		sleep 2; \
 	done; \
 	echo " ready."; \
-	proxymock record --app-port 3001 --map 13306=localhost:3306 --out "$${OUT_DIR}" > /tmp/proxymock-multi-user-record.log 2>&1 & \
+	docker exec demo-mariadb mariadb -uroot -prootpass --ssl -e "SET GLOBAL require_secure_transport=OFF"; \
+	proxymock record --app-port 3001 --map 13306=mysql://localhost:3306 --out "$${OUT_DIR}" > /tmp/proxymock-multi-user-record.log 2>&1 & \
 	PROXYMOCK_PID=$$!; \
 	sleep 3; \
-	DB_HOST=127.0.0.1 DB_PORT=13306 DB_SSL_CA=./certs/ca.pem PORT=3001 node server.js > /tmp/node-multi-user-record.log 2>&1 & \
+	DB_HOST=127.0.0.1 DB_PORT=13306 PORT=3001 node server.js > /tmp/node-multi-user-record.log 2>&1 & \
 	NODE_PID=$$!; \
 	cleanup() { \
 		kill $$NODE_PID 2>/dev/null || true; \

--- a/node-mariadb/instructions-proxymock.md
+++ b/node-mariadb/instructions-proxymock.md
@@ -37,6 +37,16 @@ make infra
 npm install
 ```
 
+Allow plaintext DB connections while recording. proxymock decodes the
+MySQL wire protocol, which it cannot do through the client's TLS
+upgrade — with TLS on you still get HTTP capture, but zero SQL. This
+is a runtime toggle (a container restart resets it to ON):
+
+```bash
+docker exec demo-mariadb mariadb -uroot -prootpass --ssl \
+  -e "SET GLOBAL require_secure_transport=OFF"
+```
+
 Install proxymock if needed:
 
 ```bash
@@ -47,7 +57,8 @@ sh -c "$(curl -Lfs https://downloads.speedscale.com/proxymock/install-proxymock)
 
 ## Shared Step 1 - Record in Environment A
 
-Terminal A:
+Terminal A. The `mysql://` prefix on the map is what turns on SQL
+decoding — a bare `13306=localhost:3306` records opaque TCP:
 
 ```bash
 OUT_DIR="proxymock/captured-$(date +%Y%m%d-%H%M%S)"
@@ -55,15 +66,22 @@ echo "$OUT_DIR"
 
 proxymock record \
   --app-port 3001 \
-  --map 13306=localhost:3306 \
+  --map 13306=mysql://localhost:3306 \
   --out "$OUT_DIR" \
   --svc-name node-mariadb-demo
 ```
 
-Terminal B:
+The recorder immediately warns `unable to connect to app port ...
+localhost:3001` — **that is expected**: the app starts *after* the
+recorder (it needs the recorder's 13306 DB port). The warning clears
+as soon as the app is up; don't Ctrl-C out of it.
+
+Terminal B (note: no `DB_SSL_CA` — the app speaks plaintext to the
+local map port while recording, which is what lets proxymock decode
+the SQL):
 
 ```bash
-DB_HOST=127.0.0.1 DB_PORT=13306 DB_SSL_CA=./certs/ca.pem PORT=3001 node server.js
+DB_HOST=127.0.0.1 DB_PORT=13306 PORT=3001 node server.js
 ```
 
 Terminal C:
@@ -201,11 +219,17 @@ Use this when an AI agent is orchestrating proxymock tools directly.
 
 ### Suggested MCP sequence
 
-1. `proxymock_record_traffic_start`
+Note: `proxymock_record_traffic_start` has no `--map` parameter, so it
+cannot capture the MariaDB side. If the agent needs DB capture, it
+should shell out to the CLI recorder from Shared Step 1
+(`proxymock record --map 13306=mysql://localhost:3306 ...`) instead of
+using the MCP record tool; the rest of the sequence is unchanged.
+
+1. `proxymock_record_traffic_start` (HTTP capture only)
    - `app-port: "3001"`
    - `proxy-in-port: "4143"`
    - `out-directory: ["proxymock/captured-<ts>"]`
-2. Agent runs app with `DB_PORT=13306`
+2. Agent runs app with `DB_PORT=13306` (no `DB_SSL_CA` — see Shared Step 1)
 3. Agent runs `generate-users-traffic.sh 4143`
 4. `proxymock_record_traffic_stop`
 5. Copy capture directory to Environment B path
@@ -242,7 +266,21 @@ Then rerun automation/replay.
 
 ### App cannot connect to DB during record
 
-Wait until proxymock map port `13306` is listening before starting app.
+- wait until proxymock map port `13306` is listening before starting app
+- make sure `require_secure_transport` was set to `OFF` (Prerequisites)
+  and the app was started **without** `DB_SSL_CA` — with TLS enforced the
+  plaintext recording connection is rejected by MariaDB
+
+### Capture has HTTP but no SQL / DB traffic
+
+Two causes, both silent:
+
+- the map was missing the protocol prefix — it must be
+  `--map 13306=mysql://localhost:3306`, not `13306=localhost:3306`
+- the app connected with TLS (`DB_SSL_CA` set); proxymock cannot decode
+  through the client's TLS upgrade. Set
+  `require_secure_transport=OFF` (Prerequisites) and drop `DB_SSL_CA`
+  for the recording run.
 
 ### 401s during replay
 

--- a/node-mariadb/test-all.sh
+++ b/node-mariadb/test-all.sh
@@ -113,18 +113,26 @@ phase_record() {
   echo -e "${BLUE}  PHASE 1: Record Traffic${NC}"
   echo -e "${BLUE}================================================================${NC}"
 
-  # Ensure MariaDB is running
+  # Ensure MariaDB is running, and allow plaintext connections for the
+  # recording run: proxymock decodes the MySQL wire protocol, which it
+  # cannot do through the client's TLS upgrade. Runtime toggle only --
+  # a container restart resets require_secure_transport to ON.
   step "1/6" "Starting MariaDB (docker)"
   docker compose up -d mariadb
   wait_for_db "$DB_REAL_PORT"
+  docker exec demo-mariadb mariadb -uroot -prootpass --ssl \
+    -e "SET GLOBAL require_secure_transport=OFF" \
+    || fail "could not disable require_secure_transport"
+  ok "require_secure_transport=OFF for recording"
 
   # Start proxymock recorder
-  #   --map 13306=localhost:3306  intercepts DB traffic on :13306 -> real DB :3306
-  #   --app-port 3001            the Node app listens on :3001
+  #   --map 13306=mysql://localhost:3306  intercepts DB traffic on :13306 -> real DB :3306
+  #                                       (mysql:// prefix enables SQL decoding)
+  #   --app-port 3001                     the Node app listens on :3001
   step "2/6" "Starting proxymock recorder"
   proxymock record \
     --app-port "$APP_PORT" \
-    --map "${DB_PROXY_PORT}=localhost:${DB_REAL_PORT}" \
+    --map "${DB_PROXY_PORT}=mysql://localhost:${DB_REAL_PORT}" \
     --out "$RECORD_DIR" \
     > /tmp/proxymock-record.log 2>&1 &
   PROXYMOCK_PID=$!
@@ -134,11 +142,12 @@ phase_record() {
   fi
   ok "proxymock recording (PID $PROXYMOCK_PID, inbound :$PROXY_IN_PORT, outbound :$PROXY_OUT_PORT)"
 
-  # Start Node app pointed at the proxymock DB proxy port
-  step "3/6" "Starting Node.js API (DB via proxymock :$DB_PROXY_PORT)"
+  # Start Node app pointed at the proxymock DB proxy port.
+  # No DB_SSL_CA: the app must speak plaintext to the map port so
+  # proxymock can decode the SQL.
+  step "3/6" "Starting Node.js API (DB via proxymock :$DB_PROXY_PORT, plaintext)"
   DB_HOST=127.0.0.1 \
   DB_PORT=$DB_PROXY_PORT \
-  DB_SSL_CA=./certs/ca.pem \
   PORT=$APP_PORT \
   node server.js > /tmp/node-record.log 2>&1 &
   NODE_PID=$!
@@ -159,11 +168,18 @@ phase_record() {
   kill "$NODE_PID" 2>/dev/null; wait "$NODE_PID" 2>/dev/null || true
   NODE_PID=""
 
-  # Summarise
+  # Summarise -- and prove the DB side was actually decoded: a capture
+  # with HTTP but zero SQL means the map prefix or TLS toggle regressed.
   step "6/6" "Recording summary"
-  local file_count
+  local file_count sql_count
   file_count=$(find "$RECORD_DIR" -name "*.md" -type f 2>/dev/null | wc -l | tr -d ' ')
   ok "Recorded ${file_count} RRPair files in ${RECORD_DIR}/"
+  sql_count=$(grep -rlE "SELECT|INSERT|UPDATE|DELETE" "$RECORD_DIR" 2>/dev/null | wc -l | tr -d ' ')
+  if [ "$sql_count" -gt 0 ]; then
+    ok "Decoded MariaDB SQL present in ${sql_count} RRPair files"
+  else
+    fail "No decoded SQL in ${RECORD_DIR} -- DB capture is empty (check mysql:// map prefix and require_secure_transport)"
+  fi
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The recording recipe in `node-mariadb` (instructions-proxymock.md, test-all.sh, and the Makefile `demo-multi-user` target) used a plain `--map 13306=localhost:3306` with the app connecting over TLS (`DB_SSL_CA=./certs/ca.pem`). This was empirically shown to capture **zero decoded MariaDB SQL** — silently:

1. the map needs an explicit protocol prefix (`mysql://`) to enable MySQL wire decoding, and
2. proxymock cannot decode through the client's TLS upgrade, and the demo MariaDB enforces `require_secure_transport=ON`.

The doc claimed "Capture: HTTP + MariaDB traffic recorded together", which was false as written.

## Changes

- Use `--map 13306=mysql://localhost:3306` in all three record recipes
- Disable `require_secure_transport` (runtime toggle, reset by container restart) before recording, and start the app **without** `DB_SSL_CA` so it speaks plaintext to the local map port
- Document the expected `unable to connect to app port 3001` recorder warning (the app intentionally starts after the recorder)
- Add troubleshooting entries for record-time DB connection failures and HTTP-but-no-SQL captures
- Note in the Option 3 (MCP) flow that `proxymock_record_traffic_start` has no `--map` parameter, so agent-driven flows must shell out to the CLI recorder for DB capture
- `test-all.sh` now **fails the record phase** if the capture contains no decoded SQL, so this can't regress silently again

## Verification

Full `./test-all.sh` run passes end-to-end (exit 0):

- Record: 13 RRPair files, decoded SQL present in 31 files (`INSERT INTO users`, `UPDATE products SET`, `SELECT * FROM products WHERE id = ...`, etc.)
- Replay without mocks: passed, 0 failed requests
- Replay with mocks: with the real MariaDB container **stopped**, proxymock served the recorded MySQL traffic — 0% failed, 0% status-code mismatch. Previously this phase always hit the "recorded DB traffic is TLS-encrypted and cannot be mocked" fallback and skipped itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)