### PR TITLE
Add external-driver replay sandwich demo

### DIFF
--- a/.github/workflows/replay-sandwich.yml
+++ b/.github/workflows/replay-sandwich.yml
@@ -1,0 +1,39 @@
+name: Replay Sandwich Driver Checks
+
+on:
+  push:
+    branches: [master, main]
+    paths:
+      - scenarios/replay-sandwich/**
+      - thoughts/scripts/verify-replay-sandwich.sh
+      - .github/workflows/replay-sandwich.yml
+  pull_request:
+    branches: [master, main]
+    paths:
+      - scenarios/replay-sandwich/**
+      - thoughts/scripts/verify-replay-sandwich.sh
+      - .github/workflows/replay-sandwich.yml
+
+permissions:
+  contents: read
+
+jobs:
+  verify-drivers:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Set up k6
+        uses: grafana/setup-k6-action@v1
+
+      - name: Install latest Postman CLI
+        run: npm install -g postman-cli@latest
+
+      - name: Verify drivers and orchestration
+        run: thoughts/scripts/verify-replay-sandwich.sh

--- a/scenarios/README.md
+++ b/scenarios/README.md
@@ -7,6 +7,7 @@ Standard demo scenarios using **Java**, **.NET**, and **Node.js** apps. Deployme
 | **[Monolith](monolith/)**                             | Run a **single** app in K8s: **Java**, **.NET**, or **Node.js** (each project’s own manifests). |
 | **[Microservices](microservices/)**                   | **Java + .NET + Node** behind one gateway in the `demo-stack` namespace.                        |
 | **[OTel Trace Replay Gate](otel-trace-replay-gate/)** | Minimal, verified proxymock record/replay merge-gate example using the `node/` demo.            |
+| **[External test drivers](replay-sandwich/)**         | Run a Speedscale replay sandwich with k6 or Postman Collection v3 as the test driver.           |
 
 ---
 

--- a/scenarios/replay-sandwich/README.md
+++ b/scenarios/replay-sandwich/README.md
@@ -1,0 +1,99 @@
+# Replay sandwich with an external test driver
+
+This scenario starts Speedscale service mocks without the Speedscale traffic generator. After the mocks are ready, the same test can be driven by k6, Postman, or another command that returns a useful exit code.
+
+The example uses the existing Node service. `GET /models` calls the Hugging Face API, so a successful isolated run proves that the application received an inbound test request and its outbound dependency was served by Speedscale.
+
+## Prerequisites
+
+- A Kubernetes cluster with Speedscale v2.5.789 or newer installed
+- `speedctl` v2.5.789 or newer, initialized for the target tenant
+- `kubectl`
+- k6 v2 or the latest Postman CLI
+- Network access from the test driver to the Node service
+
+Install the current Postman CLI with `npm install -g postman-cli@latest`. This scenario uses Postman Collection v3 YAML. It does not support Newman or the older v2.1 JSON collection format.
+
+## Deploy and capture
+
+Deploy the Node service with Speedscale capture enabled. The bundled Node traffic generator is disabled because the external driver replaces it.
+
+```bash
+kubectl apply -k k8s
+kubectl rollout status deployment/node-server -n replay-sandwich
+kubectl port-forward -n replay-sandwich service/node-server 3000:80
+```
+
+In another terminal, capture one request that reaches the external dependency.
+
+```bash
+curl --fail http://127.0.0.1:3000/models
+
+SNAPSHOT_ID=$(speedctl create snapshot \
+  --name replay-sandwich \
+  --service node-server \
+  --start 5m | jq -r .snapshot.id)
+
+speedctl wait snapshot "$SNAPSHOT_ID" --timeout 3m
+```
+
+Upload the responder-only test config. Passthrough is disabled, so an unmatched request fails instead of reaching the live dependency.
+
+```bash
+speedctl put testconfig speedscale/external-driver.json
+```
+
+## Run with k6
+
+Stop the capture port-forward before starting a replay. Speedscale can replace the application pod while it attaches mocks, which disconnects an existing port-forward. The included driver helper starts a new port-forward after `mocks-ready`. Set `SUT_URL` to a stable ingress instead when one is available.
+
+```bash
+export CLUSTER=<cluster-name>
+export NAMESPACE=replay-sandwich
+export SERVICE=node-server
+export SNAPSHOT_ID
+export SUT_URL=http://127.0.0.1:3000
+
+./run-replay-sandwich.sh -- \
+  ./drivers/run-with-port-forward.sh -- \
+    k6 run --env BASE_URL="$SUT_URL" drivers/k6/replay.js
+```
+
+k6 thresholds make assertion and HTTP failures return a nonzero exit code.
+
+## Run with Postman
+
+Lint the Native Git-compatible v3 collection before running it.
+
+```bash
+postman collection lint \
+  postman/collections/replay-sandwich \
+  --fail-severity warning
+
+./run-replay-sandwich.sh -- \
+  ./drivers/run-with-port-forward.sh -- \
+    postman collection run postman/collections/replay-sandwich \
+      --env-var "baseUrl=$SUT_URL" \
+      --bail \
+      --timeout 120000
+```
+
+Local collection runs do not require a Postman login. Collection v3 currently supports the CLI reporter, so preserve the job log as the test artifact.
+
+## Use another driver
+
+Pass any executable and its arguments after `--`:
+
+```bash
+./run-replay-sandwich.sh -- your-test-command --target "$SUT_URL"
+```
+
+The wrapper starts a responder-only replay, waits for `mocks-ready`, runs the command, and cancels the replay on success, failure, or interruption. The driver's exit code remains the CI result.
+
+## Verify the reference drivers
+
+The local verification uses a fixture server and does not require a cluster or Speedscale credentials.
+
+```bash
+thoughts/scripts/verify-replay-sandwich.sh
+```

--- a/scenarios/replay-sandwich/drivers/k6/replay.js
+++ b/scenarios/replay-sandwich/drivers/k6/replay.js
@@ -1,0 +1,28 @@
+import http from 'k6/http';
+import { check } from 'k6';
+
+const baseUrl = __ENV.BASE_URL || 'http://127.0.0.1:3000';
+
+export const options = {
+  vus: 1,
+  iterations: 1,
+  thresholds: {
+    checks: ['rate==1'],
+    http_req_failed: ['rate==0'],
+  },
+};
+
+export default function () {
+  const health = http.get(`${baseUrl}/healthz`);
+  check(health, {
+    'health status is 200': (response) => response.status === 200,
+    'service is healthy': (response) => response.status === 200 && response.json('health') === 'y',
+  });
+
+  const models = http.get(`${baseUrl}/models`);
+  check(models, {
+    'models status is 200': (response) => response.status === 200,
+    'models are returned': (response) =>
+      response.status === 200 && Array.isArray(response.json()) && response.json().length > 0,
+  });
+}

--- a/scenarios/replay-sandwich/drivers/run-with-port-forward.sh
+++ b/scenarios/replay-sandwich/drivers/run-with-port-forward.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+LOCAL_PORT=${LOCAL_PORT:-3000}
+REMOTE_PORT=${REMOTE_PORT:-80}
+READY_URL=${READY_URL:-http://127.0.0.1:${LOCAL_PORT}/healthz}
+KUBECTL_BIN=${KUBECTL_BIN:-kubectl}
+PORT_FORWARD_PID=""
+
+usage() {
+  echo "Usage: NAMESPACE=... SERVICE=... $0 -- <driver command>" >&2
+}
+
+cleanup() {
+  local status=$?
+  trap - EXIT
+  if [[ -n $PORT_FORWARD_PID ]]; then
+    kill "$PORT_FORWARD_PID" 2>/dev/null || true
+    wait "$PORT_FORWARD_PID" 2>/dev/null || true
+  fi
+  exit "$status"
+}
+
+if [[ -z ${NAMESPACE:-} || -z ${SERVICE:-} ]]; then
+  usage
+  exit 2
+fi
+if [[ ${1:-} == "--" ]]; then
+  shift
+fi
+if [[ $# -eq 0 ]]; then
+  usage
+  exit 2
+fi
+
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+"$KUBECTL_BIN" port-forward \
+  --namespace "$NAMESPACE" \
+  "service/$SERVICE" \
+  "${LOCAL_PORT}:${REMOTE_PORT}" >/dev/null 2>&1 &
+PORT_FORWARD_PID=$!
+
+for _ in $(seq 1 40); do
+  if curl --fail --silent --max-time 1 "$READY_URL" >/dev/null; then
+    "$@"
+    exit
+  fi
+  if ! kill -0 "$PORT_FORWARD_PID" 2>/dev/null; then
+    wait "$PORT_FORWARD_PID"
+  fi
+  sleep 0.25
+done
+
+echo "Port-forward did not become ready at ${READY_URL}" >&2
+exit 1

--- a/scenarios/replay-sandwich/k8s/kustomization.yaml
+++ b/scenarios/replay-sandwich/k8s/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: replay-sandwich
+resources:
+  - namespace.yaml
+  - ../../../node
+replicas:
+  - name: node-client
+    count: 0
+patches:
+  - path: node-server-patch.yaml

--- a/scenarios/replay-sandwich/k8s/namespace.yaml
+++ b/scenarios/replay-sandwich/k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: replay-sandwich

--- a/scenarios/replay-sandwich/k8s/node-server-patch.yaml
+++ b/scenarios/replay-sandwich/k8s/node-server-patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: node-server
+  annotations:
+    capture.speedscale.com/enabled: "true"
+spec:
+  template:
+    spec:
+      containers:
+        - name: node-server
+          imagePullPolicy: IfNotPresent

--- a/scenarios/replay-sandwich/postman/collections/replay-sandwich/.resources/definition.yaml
+++ b/scenarios/replay-sandwich/postman/collections/replay-sandwich/.resources/definition.yaml
@@ -1,0 +1,2 @@
+$kind: collection
+name: Replay sandwich

--- a/scenarios/replay-sandwich/postman/collections/replay-sandwich/Health.request.yaml
+++ b/scenarios/replay-sandwich/postman/collections/replay-sandwich/Health.request.yaml
@@ -1,0 +1,10 @@
+$kind: http-request
+url: "{{baseUrl}}/healthz"
+method: GET
+scripts:
+  - type: afterResponse
+    code: |-
+      pm.test('status is 200', () => pm.response.to.have.status(200));
+      pm.test('service is healthy', () => pm.expect(pm.response.json().health).to.eql('y'));
+    language: text/javascript
+order: 1000

--- a/scenarios/replay-sandwich/postman/collections/replay-sandwich/Models.request.yaml
+++ b/scenarios/replay-sandwich/postman/collections/replay-sandwich/Models.request.yaml
@@ -1,0 +1,10 @@
+$kind: http-request
+url: "{{baseUrl}}/models"
+method: GET
+scripts:
+  - type: afterResponse
+    code: |-
+      pm.test('status is 200', () => pm.response.to.have.status(200));
+      pm.test('models are returned', () => pm.expect(pm.response.json()).to.be.an('array').that.is.not.empty);
+    language: text/javascript
+order: 2000

--- a/scenarios/replay-sandwich/run-replay-sandwich.sh
+++ b/scenarios/replay-sandwich/run-replay-sandwich.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SPEEDCTL_BIN=${SPEEDCTL_BIN:-speedctl}
+TEST_CONFIG_ID=${TEST_CONFIG_ID:-external-driver}
+MOCKS_READY_TIMEOUT=${MOCKS_READY_TIMEOUT:-10m}
+POLL_INTERVAL=${POLL_INTERVAL:-5s}
+REPORT_ID=""
+
+usage() {
+  echo "Usage: SNAPSHOT_ID=... CLUSTER=... NAMESPACE=... SERVICE=... $0 -- <driver command>" >&2
+}
+
+require_env() {
+  local name=$1
+  if [[ -z ${!name:-} ]]; then
+    echo "Missing required environment variable: ${name}" >&2
+    usage
+    exit 2
+  fi
+}
+
+cleanup() {
+  local status=$?
+  trap - EXIT
+  if [[ -n $REPORT_ID ]]; then
+    echo "Canceling Speedscale replay ${REPORT_ID}"
+    "$SPEEDCTL_BIN" infra cancel-replay "$REPORT_ID" || \
+      echo "Warning: unable to cancel replay ${REPORT_ID}" >&2
+  fi
+  exit "$status"
+}
+
+for name in SNAPSHOT_ID CLUSTER NAMESPACE SERVICE; do
+  require_env "$name"
+done
+
+if [[ ${1:-} == "--" ]]; then
+  shift
+fi
+if [[ $# -eq 0 ]]; then
+  usage
+  exit 2
+fi
+
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+REPORT_ID=$(
+  "$SPEEDCTL_BIN" infra replay \
+    --snapshot-id "$SNAPSHOT_ID" \
+    --cluster "$CLUSTER" \
+    --namespace "$NAMESPACE" \
+    --service "$SERVICE" \
+    --test-config-id "$TEST_CONFIG_ID" \
+    --id-only
+)
+
+if [[ -z $REPORT_ID ]]; then
+  echo "speedctl did not return a replay ID" >&2
+  exit 1
+fi
+
+echo "Waiting for Speedscale mocks for replay ${REPORT_ID}"
+"$SPEEDCTL_BIN" wait replay "$REPORT_ID" \
+  --for mocks-ready \
+  --timeout "$MOCKS_READY_TIMEOUT" \
+  --poll-interval "$POLL_INTERVAL"
+
+echo "Mocks are ready. Starting test driver: $*"
+"$@"

--- a/scenarios/replay-sandwich/speedscale/external-driver.json
+++ b/scenarios/replay-sandwich/speedscale/external-driver.json
@@ -1,0 +1,29 @@
+{
+  "id": "external-driver",
+  "protected": false,
+  "generator": {
+    "stages": [
+      {
+        "virtualUsers": {
+          "virtualUsers": "1",
+          "requestDelay": {}
+        }
+      }
+    ]
+  },
+  "rules": [],
+  "version": 3,
+  "assertionGroups": [],
+  "responder": {
+    "numReplicas": 1,
+    "passthrough_mode": false,
+    "with_report": true
+  },
+  "cluster": {
+    "replayMode": "responder-only",
+    "logsCollected": false,
+    "sidecar_tls_out": true,
+    "cleanup": "inventory",
+    "logLevel": "info"
+  }
+}

--- a/scenarios/replay-sandwich/test/fixture-port-forward.sh
+++ b/scenarios/replay-sandwich/test/fixture-port-forward.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PORT=${LOCAL_PORT:?} exec node "${FIXTURE_SERVER:?}"

--- a/scenarios/replay-sandwich/test/fixture-server.mjs
+++ b/scenarios/replay-sandwich/test/fixture-server.mjs
@@ -1,0 +1,24 @@
+import http from 'node:http';
+
+const port = Number(process.env.PORT || 18080);
+
+const server = http.createServer((request, response) => {
+  response.setHeader('content-type', 'application/json');
+
+  if (request.url === '/healthz') {
+    response.end(JSON.stringify({ health: 'y' }));
+    return;
+  }
+
+  if (request.url === '/models') {
+    response.end(JSON.stringify([{ id: 'speedscale/replay-sandwich' }]));
+    return;
+  }
+
+  response.statusCode = 404;
+  response.end(JSON.stringify({ error: 'not found' }));
+});
+
+server.listen(port, '127.0.0.1', () => {
+  console.log(`fixture server listening on ${port}`);
+});

--- a/scenarios/replay-sandwich/test/test-orchestration.sh
+++ b/scenarios/replay-sandwich/test/test-orchestration.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCENARIO_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+TEST_TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TEST_TMP_DIR"' EXIT
+
+FAKE_SPEEDCTL="$TEST_TMP_DIR/speedctl"
+DRIVER="$TEST_TMP_DIR/driver"
+LOG_FILE="$TEST_TMP_DIR/calls.log"
+
+cat >"$FAKE_SPEEDCTL" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "$*" >>"$CALLS_LOG"
+case "$1 $2" in
+  "infra replay") echo "report-123" ;;
+  "wait replay") exit "${WAIT_EXIT_CODE:-0}" ;;
+  "infra cancel-replay") exit 0 ;;
+esac
+EOF
+
+cat >"$DRIVER" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "driver" >>"$CALLS_LOG"
+exit "${DRIVER_EXIT_CODE:-0}"
+EOF
+
+chmod +x "$FAKE_SPEEDCTL" "$DRIVER"
+
+run_sandwich() {
+  CALLS_LOG="$LOG_FILE" \
+  SPEEDCTL_BIN="$FAKE_SPEEDCTL" \
+  SNAPSHOT_ID="snapshot-123" \
+  CLUSTER="demo" \
+  NAMESPACE="replay-sandwich" \
+  SERVICE="node-server" \
+  "$SCENARIO_DIR/run-replay-sandwich.sh" -- "$DRIVER"
+}
+
+assert_line_order() {
+  local first=$1
+  local second=$2
+  local first_line second_line
+  first_line=$(grep -n "$first" "$LOG_FILE" | head -1 | cut -d: -f1)
+  second_line=$(grep -n "$second" "$LOG_FILE" | head -1 | cut -d: -f1)
+  [[ $first_line -lt $second_line ]]
+}
+
+: >"$LOG_FILE"
+run_sandwich
+assert_line_order "wait replay report-123" "^driver$"
+assert_line_order "^driver$" "infra cancel-replay report-123"
+
+: >"$LOG_FILE"
+set +e
+WAIT_EXIT_CODE=41 run_sandwich
+status=$?
+set -e
+[[ $status -eq 41 ]]
+! grep -q '^driver$' "$LOG_FILE"
+grep -q '^infra cancel-replay report-123$' "$LOG_FILE"
+
+: >"$LOG_FILE"
+set +e
+DRIVER_EXIT_CODE=42 run_sandwich
+status=$?
+set -e
+[[ $status -eq 42 ]]
+grep -q '^infra cancel-replay report-123$' "$LOG_FILE"
+
+echo "PASS: replay lifecycle gates the driver and always cancels the replay"

--- a/scenarios/replay-sandwich/test/verify-drivers.sh
+++ b/scenarios/replay-sandwich/test/verify-drivers.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCENARIO_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+POSTMAN_BIN=${POSTMAN_BIN:-postman}
+FIXTURE_PORT=${FIXTURE_PORT:-18080}
+BASE_URL="http://127.0.0.1:${FIXTURE_PORT}"
+
+with_fixture_port_forward() {
+  KUBECTL_BIN="$SCENARIO_DIR/test/fixture-port-forward.sh" \
+    FIXTURE_SERVER="$SCENARIO_DIR/test/fixture-server.mjs" \
+    NAMESPACE=fixture \
+    SERVICE=fixture \
+    LOCAL_PORT="$FIXTURE_PORT" \
+    "$SCENARIO_DIR/drivers/run-with-port-forward.sh" -- "$@"
+}
+
+with_fixture_port_forward \
+  k6 run --env BASE_URL="$BASE_URL" "$SCENARIO_DIR/drivers/k6/replay.js"
+
+COLLECTION="$SCENARIO_DIR/postman/collections/replay-sandwich"
+"$POSTMAN_BIN" collection lint "$COLLECTION" --fail-severity warning
+with_fixture_port_forward \
+  "$POSTMAN_BIN" collection run "$COLLECTION" \
+    --env-var "baseUrl=$BASE_URL" \
+    --bail \
+    --timeout 120000
+
+echo "PASS: k6 and Postman Collection v3 exercise the same API contract through the port-forward helper"

--- a/thoughts/proofs.md
+++ b/thoughts/proofs.md
@@ -1,0 +1,17 @@
+## External drivers start only after Speedscale mocks are ready and replay cleanup always runs
+- **Level**: Integration
+- **Evidence**: `thoughts/scripts/verify-replay-sandwich.sh` passed lifecycle ordering, wait failure, driver failure, and cleanup cases
+- **Status**: PROVEN
+- **Date**: 2026-07-22
+
+## k6 and Postman Collection v3 exercise the same SUT contract
+- **Level**: Integration
+- **Evidence**: `thoughts/scripts/verify-replay-sandwich.sh` passed with k6 v2.0.0 and Postman CLI v1.44.0; Postman lint reported 0 errors and 0 warnings
+- **Status**: PROVEN
+- **Date**: 2026-07-22
+
+## The replay sandwich works in Kubernetes with Speedscale responders
+- **Level**: Deployment
+- **Evidence**: A responder-only replay in minikube provisioned the real Speedscale responder, collector, and Redis. k6 passed 4/4 checks in 79 ms and Postman CLI v1.44.0 passed 2 requests and 4/4 assertions in 188 ms while the responder was active. The v2.5.778 operator did not publish the `MocksReady` condition required by the v2.5.789 CLI, confirming the documented minimum applies to the cluster installation as well as `speedctl`.
+- **Status**: PROVEN
+- **Date**: 2026-07-22

--- a/thoughts/scripts/verify-replay-sandwich.sh
+++ b/thoughts/scripts/verify-replay-sandwich.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Proves the external-driver lifecycle and both reference drivers work locally.
+# Created: 2026-07-22 for the replay sandwich reference scenario.
+
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+SCENARIO_DIR="$REPO_ROOT/scenarios/replay-sandwich"
+
+"$SCENARIO_DIR/test/test-orchestration.sh"
+"$SCENARIO_DIR/test/verify-drivers.sh"
+
+kubectl kustomize "$SCENARIO_DIR/k8s" >/dev/null
+
+echo "PASS: replay sandwich reference scenario passed local verification"


### PR DESCRIPTION
## Problem
Customers need to run Speedscale service mocks with their existing test driver instead of the Speedscale generator. There is no runnable reference covering readiness, driver failure propagation, and cleanup.

## Solution
Add a responder-only replay wrapper, fail-closed test config, Kubernetes reference app, k6 driver, and Postman Collection v3 YAML for the latest Postman CLI. Add a post-readiness port-forward helper, lifecycle tests, local driver verification, and a path-filtered CI workflow.

## Validation
- Local lifecycle tests cover readiness ordering, wait failure, driver failure, and replay cleanup
- k6 v2.0.0 passes 4 of 4 checks
- Postman CLI v1.44.0 lint passes with 0 warnings and the run passes 4 of 4 assertions
- A real minikube responder-only replay served the mocked outbound dependency to both drivers
- kubectl kustomize succeeds